### PR TITLE
CONT: Updating other integrations pages and apple table results

### DIFF
--- a/src/devicedetection/features/appledevicetable.md
+++ b/src/devicedetection/features/appledevicetable.md
@@ -8,7 +8,7 @@ Below we cover the detection results that are experienced for each iPhone and iP
 
 The 'percentage' column refers to the percentage of the data submissions we have received that would return that detection result for that particular display mode. For example, '100.00%' in Standard mode indicates that 100% of our submissions for that device would receive that result if the data from the submission were passed to our detection script. '1.50%' in indicates that 1.5% of our submissions would receive that detection result.
 
-As we receive more data on Apple devices, this table will change. We will update this table every two months and it is currently accurate as of 2 May 2023.
+As we receive more data on Apple devices, this table will change. We will update this table every two months and it is currently accurate as of 4 July 2023.
 
 For optimized viewing of the table, it is recommended you zoom out within your browser.
 

--- a/src/otherintegrations/nginx.md
+++ b/src/otherintegrations/nginx.md
@@ -5,23 +5,7 @@
 We have also integrated our Device Detection to Nginx. This page describes in detail how you can install and use our module in your Nginx environment.
 # Prerequisites
 
-## Dependencies:
-* gcc
-* make
-* zlib1g-dev
-* libpcre3
-* libpcre3-dev
-
-## Tested versions:
-* Nginx 1.21.3, 1.20.0, 1.19.0, 1.19.5, 1.19.10
-* C11 or above
-
-## Tested platforms:
-* Ubuntu 18.04
-* Ubuntu 20.04
-
-## Tested architectures:
-* 64-bit
+For the latest dependencies, tested version, and tester platforms information, please refer to our @testedversions and @dependencies pages.
 
 # Installing
 If you haven’t already, you can obtain a copy of the latest version of the API [here](https://github.com/51Degrees/device-detection-nginx).

--- a/src/otherintegrations/nginx.md
+++ b/src/otherintegrations/nginx.md
@@ -5,7 +5,7 @@
 We have also integrated our Device Detection to Nginx. This page describes in detail how you can install and use our module in your Nginx environment.
 # Prerequisites
 
-For the latest dependencies, tested version, and tester platforms information, please refer to our @testedversions and @dependencies pages.
+For the latest dependencies, tested version, and tested platforms information, please refer to our @testedversions and @dependencies pages.
 
 # Installing
 If you haven’t already, you can obtain a copy of the latest version of the API [here](https://github.com/51Degrees/device-detection-nginx).

--- a/src/otherintegrations/varnish.md
+++ b/src/otherintegrations/varnish.md
@@ -5,26 +5,7 @@ We have also integrated our Device Detection to Varnish. This page details an ov
 
 # Prerequisites
 
-## Dependencies:
-* gcc
-* make
-* automake
-* autotools-dev
-* libtool
-* python
-* Varnish source
-
-## Tested versions:
-* Varnish 6.0.8 (LTS)
-* C11 or above
-* libatomic1
-
-## Tested platforms:
-* Ubuntu 18.04
-* Ubuntu 20.04
-
-## Tested architectures:
-* 64-bit
+For the latest dependencies, tested version, and tested platforms information, please refer to our @testedversions and @dependencies pages.
 
 # Installing
 If you haven’t already, you can obtain a copy of the latest version of the API [here](https://github.com/51Degrees/device-detection-varnish).


### PR DESCRIPTION
Updating the NGINX and Varnish other integrations pages to link to the tested versions and dependencies pages. Also updating the apple results table for july. No change other than the date