### PR TITLE
FIX: Docs snippet links

### DIFF
--- a/src/examples/devicedetection/performance/onpremisehash.md
+++ b/src/examples/devicedetection/performance/onpremisehash.md
@@ -9,11 +9,10 @@ A [feature page](@ref DeviceDetection_Features_PerformanceOptions) is also avail
 @startsnippets
 @grabexample{device-detection-cxx,_hash_2_performance_8c,C}
 @showsnippet{cpp,C++}
-@grabexample{device-detection-dotnet,_hash_2_performance_2_program_8cs,C#}
+@grabexample{device-detection-dotnet,_on_premise_2_performance-_console_2_program_8cs,C#}
 @grabexample{device-detection-java,_performance_benchmark_8java,Java}
 @showsnippet{php,PHP}
 @grabexample{device-detection-node,onpremise_2performance-console_2performance_8js,Node.js}
-@grabexample{device-detection-python,onpremise_2performance_8py,Python}
 @startsnippet{cpp}
 There is no performance example for C++, see the C tab instead.
 @endsnippet

--- a/src/examples/reversegeocoding/webintegration/examples.md
+++ b/src/examples/reversegeocoding/webintegration/examples.md
@@ -5,11 +5,10 @@
 This example shows how to integrate a Pipeline running a @reversegeocoding engine into various web frameworks.
 
 @startsnippets
-@grabexample{location-dotnet,_asp_net_core3_81_2_startup_8cs,C# - ASP.NET Core}
+@grabexample{location-dotnet,_asp_net_core_2_startup_8cs,C# - ASP.NET Core}
 @grabexample{location-java,servlet_2_example_8java,Java Servlet}
 @grabexample{location-java,mvc_2configuration_2_example_mvc_config_8java,Java Spring MVC}
 @grabexample{location-node,web_integration_8js,Node.js}
 @grabexample{location-php,cloud_2web_integration_8php,PHP}
-@grabexample{location-python,cloud_2web_8py,Python}
 @grabbedexample
 @endsnippets

--- a/src/examples/webintegration.md
+++ b/src/examples/webintegration.md
@@ -14,7 +14,6 @@ For engine-specific examples, see:
 - [reverse geocoding web integration](@ref Examples_ReverseGeocoding_WebIntegration_Examples)
 
 @startsnippets
-@grabexample{pipeline-dotnet,_net_core2_81_2_startup_8cs,C# - ASP.NET Core}
 @grabexample{pipeline-dotnet,_example_framework_web_site_2_controllers_2_home_controller_8cs,C# - ASP.NET Framework}
 @grabbedexample
 @endsnippets


### PR DESCRIPTION
fixed the snippet links and removed unfinished python ones. Should be added back later. 