### PR TITLE
usagesharing not supported for PHP and Go

### DIFF
--- a/src/features/usagesharing.md
+++ b/src/features/usagesharing.md
@@ -14,12 +14,11 @@ deemed reliable enough to contribute to the data file.
 
 # How to enable usage sharing
 
-**Usage sharing** is enabled by default if you are using a pipeline builder that is derived from a 51Degrees pipeline builder (for example, DeviceDetetctionPipelineBuilder or FiftyOnePipelineBuilder). To configure the **usage sharing** feature, please refer to our @ref Examples_UsageSharing examples.
+**Usage sharing** is enabled by default if you are using a pipeline builder that is derived from a 51Degrees pipeline builder (for example, DeviceDetetctionPipelineBuilder or FiftyOnePipelineBuilder). To configure the **usage sharing** feature, please refer to our @ref Examples_UsageSharing.
 
 To enable **usage sharing** for low-level APIs such as C, Nginx, and Varnish, please refer to the [Usage Sharing for low-level APIs section](@ref Low_Level_Usage_Sharing) further down this page.
 
-At this time, we do not have **usage sharing** for PHP and Go. If you'd like to make a feature
-request, please [get in touch](https://51degrees.com/contact-us).
+Please refer to the @ref Examples_UsageSharing section to check if **user sharing** is implemented for a particular language or API. To request an additional implementation of this feature, please [get in touch](https://51degrees.com/contact-us).
 
 If you have any questions on how we use the data you share with us via usage sharing, please refer to our blog [Usage sharing: how do we use your data](https://51degrees.com/blog/usage-sharing-how-do-we-use-your-data).
 

--- a/src/features/usagesharing.md
+++ b/src/features/usagesharing.md
@@ -18,7 +18,7 @@ deemed reliable enough to contribute to the data file.
 
 To enable **usage sharing** for low-level APIs such as C, Nginx, and Varnish, please refer to the [Usage Sharing for low-level APIs section](@ref Low_Level_Usage_Sharing) further down this page.
 
-At this time, we do not have **usage sharing** for PHP or other languages. If you'd like to make a feature
+At this time, we do not have **usage sharing** for PHP and Go. If you'd like to make a feature
 request, please [get in touch](https://51degrees.com/contact-us).
 
 If you have any questions on how we use the data you share with us via usage sharing, please refer to our blog [Usage sharing: how do we use your data](https://51degrees.com/blog/usage-sharing-how-do-we-use-your-data).


### PR DESCRIPTION
instead of hardcoding concrete language mentions (s.a. php or go) - we refer the user to the examples section to check if UsageSharing is implemented for a particular language or API.  