### PR TITLE
DOC: add bottom margin under all heading variants

### DIFF
--- a/pattern-library/source/sass/01-base/00-text.scss
+++ b/pattern-library/source/sass/01-base/00-text.scss
@@ -62,7 +62,7 @@
   font-weight:$font-weight-bold;
   font-size:size(2);
   color:$colour-black;
-  margin:0;
+  margin:0 0 size(3) 0;
 }
 
 .b-text--heading-1 {
@@ -74,7 +74,7 @@
   font-weight:$font-weight-bold;
   font-size:size(1);
   color:$colour-black;
-  margin:0;
+  margin:0 0 size(2) 0;
 }
 
 .b-text--heading-2 {
@@ -86,7 +86,7 @@
   font-weight:$font-weight-bold;
   font-size:size(0);
   color:$colour-black;
-  margin:0;
+  margin:0 0 size(1) 0;
 }
 
 .b-text--heading-3 {

--- a/pattern-library/source/sass/04-layouts/01-docs/00-docs-index.scss
+++ b/pattern-library/source/sass/04-layouts/01-docs/00-docs-index.scss
@@ -103,6 +103,7 @@
 
   .g-docs__page-title {
     font-size: size(2);
+    margin: 0 0 size(3) 0;
     @include respond-to(sm) {
       font-size: size(3);
     }


### PR DESCRIPTION
## Summary

Headings inside `.g-docs__primary` had `margin:0` from their text mixins, so they sat flush against the following paragraph. Section headings and the page title also looked tight. This adds bottom margin to every heading variant so content has visible breathing room.

| Selector | Before | After |
|----------|--------|-------|
| h1 mixin / `.b-text--heading-1` | 0 | 1.728rem |
| h2 mixin / `.b-text--heading-2` | 0 | 1.44rem |
| h3 mixin / `.b-text--heading-3` | 0 | 1.2rem |
| `.g-docs__page-title` | UA default | 1.728rem |

## Follow-up

`docs/docs-main.css` and `docs/docs-main.min.css` need regeneration from this source via the pattern-library Docker build (`docker build --output=build .` per `pattern-library/README.md`). Doing that as a separate commit keeps autoprefixer/clean-css output untouched.

## Test plan

- [x] Verified rendered docs (gh-pages 4.5) locally — page title, section headings, and bare h2/h3 all show the new bottom margins.
- [x] Reviewer to eyeball rendered preview artifact from the preview workflow.