### PR TITLE
gh-pages preview publishing

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,40 @@
+name: Cleanup Preview Documentation
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  Cleanup:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          fetch-depth: 2
+
+      - env:
+          PREVIEW_DIR: preview/PR-${{ github.event.pull_request.number }}
+        run: |
+          if [[ ! -d "$PREVIEW_DIR" ]]; then
+            echo "No preview to clean up at $PREVIEW_DIR."
+            exit 0
+          fi
+          rm -rf "$PREVIEW_DIR"
+          git add -- "$PREVIEW_DIR"
+          if git diff --cached --quiet; then
+            echo "Nothing staged after removal."
+            exit 0
+          fi
+          git -c user.name='github-actions[bot]' \
+              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+              commit -m "Remove preview for PR #${{ github.event.pull_request.number }}"
+          for i in 1 2 3; do
+            git pull --rebase origin gh-pages && git push origin HEAD:gh-pages && exit 0
+            sleep $((i * 5))
+          done
+          echo "Failed to push cleanup after retries." >&2
+          exit 1

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,16 +7,90 @@ on:
 jobs:
   Preview:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 10.x
+
+      - id: ctx
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "prefix=preview/PR-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "name=PR-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            if [[ "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]]; then
+              echo "can_publish=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            safe_branch="$(echo "${GITHUB_REF_NAME}" | tr '/' '-' | tr -cd '[:alnum:]-_.')"
+            echo "prefix=preview/branch-${safe_branch}" >> "$GITHUB_OUTPUT"
+            echo "name=branch-${safe_branch}" >> "$GITHUB_OUTPUT"
+            echo "can_publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - run: pwsh ci/build-pattern-library.ps1
-      - run: pwsh ci/generate-documentation.ps1
-      - uses: actions/upload-artifact@v7
+      - run: pwsh ci/generate-documentation.ps1 -DestinationPrefix "${{ steps.ctx.outputs.prefix }}"
+
+      - if: steps.ctx.outputs.can_publish == 'true'
+        working-directory: gh-pages
+        env:
+          PREVIEW_PREFIX: ${{ steps.ctx.outputs.prefix }}
+          PREVIEW_NAME: ${{ steps.ctx.outputs.name }}
+        run: |
+          git add -- "$PREVIEW_PREFIX"
+          if git diff --cached --quiet; then
+            echo "No preview changes to publish."
+            exit 0
+          fi
+          git -c user.name='github-actions[bot]' \
+              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+              commit -m "Preview docs for ${PREVIEW_NAME}"
+          for i in 1 2 3; do
+            git pull --rebase origin gh-pages && git push origin HEAD:gh-pages && exit 0
+            sleep $((i * 5))
+          done
+          echo "Failed to push preview after retries." >&2
+          exit 1
+
+      - id: url
+        if: steps.ctx.outputs.can_publish == 'true'
+        shell: bash
+        env:
+          PREVIEW_PREFIX: ${{ steps.ctx.outputs.prefix }}
+        run: |
+          version=$(ls -t "gh-pages/$PREVIEW_PREFIX" 2>/dev/null | head -1)
+          if [[ -z "$version" ]]; then
+            echo "Could not determine version directory under gh-pages/$PREVIEW_PREFIX." >&2
+            exit 1
+          fi
+          echo "preview_url=https://51degrees.github.io/documentation/$PREVIEW_PREFIX/$version/" >> "$GITHUB_OUTPUT"
+
+      - if: steps.ctx.outputs.can_publish == 'true'
+        run: |
+          echo "Preview published at ${{ steps.url.outputs.preview_url }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - if: steps.ctx.outputs.can_publish == 'true' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          PREVIEW_URL: ${{ steps.url.outputs.preview_url }}
+        run: |
+          if gh api --paginate "repos/$REPO/issues/$PR/comments" --jq '.[].body' | grep -q '<!-- preview-link -->'; then
+            echo "Preview comment already present; skipping."
+            exit 0
+          fi
+          body=$'<!-- preview-link -->\nDocumentation preview: '"$PREVIEW_URL"$'\n\nThis link updates with every push to this PR and is removed when the PR is closed.'
+          gh api "repos/$REPO/issues/$PR/comments" -f body="$body"
+
+      - if: steps.ctx.outputs.can_publish != 'true'
+        uses: actions/upload-artifact@v7
         with:
-          name: docs_${{ inputs.pull-request-id }}
-          path: gh-pages/*
+          name: docs_fork_${{ github.event.pull_request.number }}
+          path: gh-pages/${{ steps.ctx.outputs.prefix }}
           if-no-files-found: ignore
           include-hidden-files: true

--- a/ci/generate-documentation.ps1
+++ b/ci/generate-documentation.ps1
@@ -1,3 +1,7 @@
+param(
+    [string]$DestinationPrefix = ""
+)
+
 $ErrorActionPreference = "Stop"
 $PSNativeCommandUseErrorActionPreference = $true
 
@@ -58,8 +62,11 @@ foreach ($_ in $repoMap.GetEnumerator()) {
 Write-Host "::group::Checking out gh-pages"
 git fetch --force --depth 2 origin gh-pages:gh-pages
 git worktree add gh-pages # check out gh-pages as a worktree
-Remove-Item -Recurse -Force -ErrorAction SilentlyContinue gh-pages/$version
-Move-Item $version gh-pages/$version
+$destDir = if ($DestinationPrefix) { "gh-pages/$DestinationPrefix/$version" } else { "gh-pages/$version" }
+$destParent = Split-Path -Parent $destDir
+if (!(Test-Path $destParent)) { New-Item -ItemType Directory -Force $destParent | Out-Null }
+Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $destDir
+Move-Item $version $destDir
 Write-Host "::endgroup::"
 
 if (!(Test-Path "gh-pages/.nojekyll")) {


### PR DESCRIPTION
- generates a PR preview and adds it to the gh-pages branch under `preview/PR-<number>`
- when additional commits are pushed - the preview is regenerated
- when PR is closed or merged - it should delete the preview from gh-pages branch - so we don't accumulate them