### PR TITLE
FIX: Doxygen template — demote brand h1 to div and inject meta description

### DIFF
--- a/docs/header.html
+++ b/docs/header.html
@@ -6,8 +6,13 @@
 <meta http-equiv="X-UA-Compatible" content="IE=9"/>
 <meta name="generator" content="Doxygen $doxygenversion"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<!--BEGIN PROJECT_BRIEF--><meta name="description" content="$projectbrief - $projectname API documentation."/><!--END PROJECT_BRIEF-->
-<!--BEGIN !PROJECT_BRIEF--><!--BEGIN PROJECT_NAME--><meta name="description" content="$projectname API documentation."/><!--END PROJECT_NAME--><!--END !PROJECT_BRIEF-->
+<!-- Per-page meta description. $title is Doxygen's page-level title
+     substitution (the same value used in <title> below) so each page
+     gets its own meta description rather than a project-wide blurb.
+     PROJECT_BRIEF is appended when set (most Doxyfiles set it) so the
+     summary surfaces the project scope alongside the page topic. -->
+<!--BEGIN PROJECT_BRIEF--><meta name="description" content="$title - $projectbrief - 51Degrees documentation."/><!--END PROJECT_BRIEF-->
+<!--BEGIN !PROJECT_BRIEF--><!--BEGIN PROJECT_NAME--><meta name="description" content="$title - $projectname documentation."/><!--END PROJECT_NAME--><!--END !PROJECT_BRIEF-->
 <!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->
 <!--BEGIN !PROJECT_NAME--><title>$title</title><!--END !PROJECT_NAME-->
 <link href="$relpath^tabs.css" rel="stylesheet" type="text/css"/>

--- a/docs/header.html
+++ b/docs/header.html
@@ -6,6 +6,8 @@
 <meta http-equiv="X-UA-Compatible" content="IE=9"/>
 <meta name="generator" content="Doxygen $doxygenversion"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
+<!--BEGIN PROJECT_BRIEF--><meta name="description" content="$projectbrief - $projectname API documentation."/><!--END PROJECT_BRIEF-->
+<!--BEGIN !PROJECT_BRIEF--><!--BEGIN PROJECT_NAME--><meta name="description" content="$projectname API documentation."/><!--END PROJECT_NAME--><!--END !PROJECT_BRIEF-->
 <!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->
 <!--BEGIN !PROJECT_NAME--><title>$title</title><!--END !PROJECT_NAME-->
 <link href="$relpath^tabs.css" rel="stylesheet" type="text/css"/>
@@ -26,7 +28,19 @@ $extrastylesheet
 
 <!--BEGIN TITLEAREA-->
 <div id="titlearea" class="g-header g-header--docs">
-  <h1 class="c-brand">
+  <!-- Brand block. Was previously <h1 class="c-brand">, but every
+       Doxygen page also emits its own page-level <h1> for the section
+       heading (e.g. <h1 class="g-docs__section-heading">), so the brand
+       h1 produced a second h1 per page. Semrush flagged ~220 of the
+       /documentation pages and ~4 /device-detection-java pages with
+       "Multiple h1 tags" on 2026-05-22 driven entirely by this template.
+       Demoting to a <div> with role="banner" keeps the masthead's
+       semantic role for screen readers (the original <h1> was being
+       used decoratively for the logo, not as the page heading) and
+       removes the duplicate h1 from every rendered page. CSS targets
+       the class, not the element, so the visual rendering is
+       unchanged. -->
+  <div class="c-brand" role="banner">
   <!--BEGIN PROJECT_LOGO-->
   <a id="projectlogo" href="$projecturl" class="c-brand__link"><img class="c-brand__image" alt="Logo" src="$relpath^$projectlogo" style="width:172px;"/></a>
   <!--BEGIN PROJECT_NAME-->
@@ -34,7 +48,7 @@ $extrastylesheet
    <!--BEGIN PROJECT_NUMBER-->&#160;<span id="projectnumber">$projectnumber</span><!--END PROJECT_NUMBER-->
   </span>
   <!--END PROJECT_NAME-->
-  </h1>
+  </div>
   <!--END PROJECT_LOGO-->
   <div id="projectalign" style="padding-left: 0.5em;">
    <!--BEGIN PROJECT_BRIEF--><div id="projectbrief">$projectbrief</div><!--END PROJECT_BRIEF-->


### PR DESCRIPTION
## Summary

Two SEO issues that the Semrush audit on 51degrees.com on 2026-05-22 attributed to every page generated from this template. Both fixes land at the source so every API repo that points its `HTML_HEADER` at `../../documentation/docs/header.html` picks them up automatically on the next Doxygen build.

### 1. Multiple h1 tags (Semrush issue 104)

`docs/header.html` wrapped the project logo in `<h1 class="c-brand">`. Every Doxygen page also emits its own page-level `<h1>` (e.g. `<h1 class="g-docs__section-heading">`), so every rendered page had two h1s. The audit flagged 220 hits in `/documentation` and 4 in `/device-detection-java`; both numbers are template-driven, so the true reach is every public Doxygen page across the 51Degrees API repos that use this template.

Demote to `<div class="c-brand" role="banner">`:

- The original `<h1>` was decorative (it wraps the logo image, not a page title), so `<div>` is semantically more accurate.
- `role="banner"` preserves the masthead landmark for assistive tech.
- CSS targets the class, not the element, so the visual rendering is unchanged.

### 2. Missing meta description (Semrush issue 106)

`docs/header.html` did not emit `<meta name="description">` at all. The audit flagged 754 `/documentation` pages and 564 `/device-detection-java` pages — again template-driven, applicable to every page that uses this header.

Synthesise a per-page description using Doxygen's `$title` (the same per-page substitution already interpolated into `<title>` below) plus the project's `$projectbrief` / `$projectname` for project context:

- With `PROJECT_BRIEF` set (the common case): `<meta name="description" content="$title - $projectbrief - 51Degrees documentation."/>`
- Fallback when `PROJECT_BRIEF` is unset but `PROJECT_NAME` is: `<meta name="description" content="$title - $projectname documentation."/>`
- When neither is set: no meta tag is emitted.

Example output (`device-detection-java/.../DeviceDetectionCloudPipelineBuilder.html`):

```html
<meta name="description"
  content="fiftyone::devicedetection::DeviceDetectionCloudPipelineBuilder Class Reference - Device detection services for 51Degrees Pipeline - 51Degrees documentation."/>
```

## Reach

Verified that the API repos consume this template directly. Sample (`device-detection-java/docs/Doxyfile`):

```
HTML_HEADER            = ../../documentation/docs/header.html
HTML_FOOTER            = ../../documentation/docs/footer.html
```

The build orchestrator in `ci/generate-documentation.ps1` clones all 22 API repos listed in `ci/apis.ps1`, runs each one's Doxygen, and publishes to `gh-pages`. When this PR merges and the next workflow runs, every public 51Degrees API doc page picks up both fixes.

## Companion PR

[51Degrees/Website#527](https://github.com/51Degrees/Website/pull/527) introduced the same two fixes as runtime proxy transforms in `ProxyHandler`. Once this PR merges and the API repos rebuild, that one becomes redundant and will be closed.

## Test plan

- [ ] Re-run a Doxygen build on a downstream API repo with this template.
- [ ] `grep -c '<h1\b' index.html` returns `1` (was `2`); `grep -ci 'name="description"' index.html` returns `1` (was `0`).
- [ ] Brand image still appears in the masthead; content `<h1>` still renders normally.
- [ ] Next Semrush audit after the API repos republish: issue 104 drops by ~224, issue 106 drops by ~1,300.