### PR TITLE
REF: Move header.html design notes to HEADER-NOTES.md (per #141)

### DIFF
--- a/docs/HEADER-NOTES.md
+++ b/docs/HEADER-NOTES.md
@@ -1,0 +1,57 @@
+# `header.html` design notes
+
+Background for the non-obvious shapes in `header.html`. Kept in a sibling
+file rather than as HTML comments inside the template so the rationale
+doesn't ship into every rendered page.
+
+## Why the brand block is a `<div class="c-brand">` not an `<h1 class="c-brand">`
+
+Every Doxygen-generated page also emits its own page-level `<h1>`
+(commonly `<h1 class="g-docs__section-heading">` from the standard
+layout). When the masthead brand was also wrapped in `<h1>`, every
+rendered page carried two `<h1>` tags.
+
+The Semrush audit of 51degrees.com on 2026-05-22 flagged 220 pages in
+`/documentation/*` and 4 in `/device-detection-java/*` as "Multiple h1
+tags" purely from this template (Semrush issue 104). Because the
+documentation repo's `header.html` is the `HTML_HEADER` for every API
+repo's Doxyfile (`HTML_HEADER = ../../documentation/docs/header.html`),
+the bad shape multiplied across every public Doxygen page.
+
+The brand element wraps a logo image. It is decorative, not the page
+heading, so demoting it to a `<div>` is semantically more accurate.
+`role="banner"` keeps the masthead landmark for assistive tech, and
+the CSS targets the class (`c-brand`), not the element, so the visual
+rendering is unchanged.
+
+## Why the meta description is conditional on `PROJECT_BRIEF`
+
+The Semrush audit flagged 754 `/documentation/*` pages and 564
+`/device-detection-java/*` pages with "Missing meta description"
+(Semrush issue 106). Doxygen does not emit `<meta name="description">`
+by default; the template now synthesises one from Doxygen's
+substitutions:
+
+- When `PROJECT_BRIEF` is set (the common case for API repos):
+  `<meta name="description"
+    content="$title - $projectbrief - 51Degrees documentation."/>`
+- When only `PROJECT_NAME` is set:
+  `<meta name="description"
+    content="$title - $projectname documentation."/>`
+- When neither is set: nothing is emitted (better than misleading
+  boilerplate).
+
+`$title` is Doxygen's per-page title substitution (the same value
+already interpolated into `<title>` below), so each page gets its own
+description rather than a project-wide blurb.
+
+## Why these notes are not inline comments
+
+A prior version had this rationale as `<!-- ... -->` blocks inside
+`header.html`. Doxygen copies HTML comments verbatim into every
+rendered page, so two long explanatory blocks added ~1.5 KB per page
+to roughly 5,500 generated pages: about 8 MB of bandwidth on every
+full crawl, plus the per-visitor cost. Tracked in
+[#141](https://github.com/51Degrees/documentation/issues/141).
+
+Keep new design notes in this file; only put pointers in the template.

--- a/docs/header.html
+++ b/docs/header.html
@@ -6,11 +6,6 @@
 <meta http-equiv="X-UA-Compatible" content="IE=9"/>
 <meta name="generator" content="Doxygen $doxygenversion"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<!-- Per-page meta description. $title is Doxygen's page-level title
-     substitution (the same value used in <title> below) so each page
-     gets its own meta description rather than a project-wide blurb.
-     PROJECT_BRIEF is appended when set (most Doxyfiles set it) so the
-     summary surfaces the project scope alongside the page topic. -->
 <!--BEGIN PROJECT_BRIEF--><meta name="description" content="$title - $projectbrief - 51Degrees documentation."/><!--END PROJECT_BRIEF-->
 <!--BEGIN !PROJECT_BRIEF--><!--BEGIN PROJECT_NAME--><meta name="description" content="$title - $projectname documentation."/><!--END PROJECT_NAME--><!--END !PROJECT_BRIEF-->
 <!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->
@@ -33,18 +28,6 @@ $extrastylesheet
 
 <!--BEGIN TITLEAREA-->
 <div id="titlearea" class="g-header g-header--docs">
-  <!-- Brand block. Was previously <h1 class="c-brand">, but every
-       Doxygen page also emits its own page-level <h1> for the section
-       heading (e.g. <h1 class="g-docs__section-heading">), so the brand
-       h1 produced a second h1 per page. Semrush flagged ~220 of the
-       /documentation pages and ~4 /device-detection-java pages with
-       "Multiple h1 tags" on 2026-05-22 driven entirely by this template.
-       Demoting to a <div> with role="banner" keeps the masthead's
-       semantic role for screen readers (the original <h1> was being
-       used decoratively for the logo, not as the page heading) and
-       removes the duplicate h1 from every rendered page. CSS targets
-       the class, not the element, so the visual rendering is
-       unchanged. -->
   <div class="c-brand" role="banner">
   <!--BEGIN PROJECT_LOGO-->
   <a id="projectlogo" href="$projecturl" class="c-brand__link"><img class="c-brand__image" alt="Logo" src="$relpath^$projectlogo" style="width:172px;"/></a>


### PR DESCRIPTION
## Summary

The brand and meta-description blocks in `docs/header.html` carried two long HTML comment blocks explaining their shape. Doxygen copies HTML comments verbatim into every rendered page, so those blocks were adding roughly 1.5 KB to each of the ~5,500 pages produced by the central documentation build and the 22 API repos that consume this template via `HTML_HEADER`. That is ~8 MB per full crawl on top of the per-visitor cost.

Move the rationale to `docs/HEADER-NOTES.md` (visible to anyone reading the repo, invisible to anyone fetching a rendered page) and leave just the working markup in `header.html`. No behaviour change in what Doxygen emits.

## Verification

- `header.html` still has the same template variables and same emitted markup once Doxygen runs its substitution pass.
- Rebuild via the existing `Build Documentation` workflow will drop the comment bytes from every page on next run.

Resolves #141.