### PR TITLE
FEAT: Mirror current-version HTML to unversioned root (Semrush #214 fix at source)

### DIFF
--- a/ci/generate-documentation.ps1
+++ b/ci/generate-documentation.ps1
@@ -65,3 +65,39 @@ Write-Host "::endgroup::"
 if (!(Test-Path "gh-pages/.nojekyll")) {
     '' > "gh-pages/.nojekyll"
 }
+
+# Mirror the current version's HTML at the unversioned path so links
+# like /documentation/_foo.html resolve directly without redirecting.
+# Each mirror gets <base href="/documentation/<version>/"> so relative
+# asset and nav refs still resolve into the versioned tree, and a
+# canonical link pointing back at the unversioned form so search
+# engines index that as the canonical URL.
+#
+# A .mirror-manifest at the gh-pages root records what we wrote so the
+# next run (after a version bump or a Doxygen page rename) cleans up
+# stale mirrors before recreating fresh ones.
+Write-Host "::group::Mirroring current-version HTML to unversioned root"
+$manifestPath = "gh-pages/.mirror-manifest"
+if (Test-Path $manifestPath) {
+    Get-Content $manifestPath | Where-Object { $_ } | ForEach-Object {
+        Remove-Item -Force -ErrorAction SilentlyContinue (Join-Path "gh-pages" $_)
+    }
+}
+$srcRoot = (Resolve-Path "gh-pages/$version").Path
+$baseTag = "<base href=`"/documentation/$version/`">"
+$mirrored = [System.Collections.Generic.List[string]]::new()
+Get-ChildItem -Recurse -File -Filter "*.html" -Path "gh-pages/$version" | ForEach-Object {
+    $rel = $_.FullName.Substring($srcRoot.Length + 1) -replace '\\', '/'
+    $dest = Join-Path "gh-pages" $rel
+    New-Item -ItemType Directory -Force (Split-Path $dest) | Out-Null
+    $content = Get-Content $_.FullName -Raw
+    $canonicalTag = "<link rel=`"canonical`" href=`"/documentation/$rel`">"
+    if ($content -notmatch '<base\s') {
+        $content = $content -replace '(<head[^>]*>)', "`$1`n  $baseTag`n  $canonicalTag"
+    }
+    Set-Content -Path $dest -Value $content -NoNewline
+    $mirrored.Add($rel)
+}
+Set-Content -Path $manifestPath -Value ($mirrored -join "`n")
+Write-Host "Mirrored $($mirrored.Count) HTML files to gh-pages root."
+Write-Host "::endgroup::"


### PR DESCRIPTION
GitHub Pages already serves \`/documentation/<version>/_foo.html\`. This PR mirrors the current version's HTML files at the **unversioned** path too, so 51degrees.com can link to \`/documentation/_foo.html\` and get a 200 directly instead of bouncing through a 308.

The website's Semrush audit currently flags **785 outbound internal redirects** (defect #214) — almost all of them \`/documentation/_*.html\` -> \`/documentation/4.5/_*.html\` 308s emitted by the ProxyHandler when it can't find the unversioned path upstream. After this lands the upstream fetch succeeds and the redirect chain disappears.

## What the build script does now

After \`Move-Item $version gh-pages/$version\` (line 62), one new block:

1. **Cleanup stale mirrors** from the previous run via a \`.mirror-manifest\` file at the gh-pages root. Covers Doxygen page renames and version bumps without leaving orphans behind.
2. **Walk \`gh-pages/$version\` recursively** for every \`.html\` file.
3. **Copy each to its unversioned path** at the gh-pages root (preserving nested directory structure like \`apis/device-detection-cxx/\`).
4. **Inject two tags after \`<head>\`**:
   - \`<base href="/documentation/<version>/">\` so relative asset (CSS / JS / image) and nav refs in the mirrored HTML still resolve into the versioned tree — no asset duplication needed.
   - \`<link rel="canonical" href="/documentation/<rel-path>">\` so search engines index the unversioned URL as authoritative.
5. **Record what was written** in the manifest for next-run cleanup.

\`<base>\` is skipped if a doc already has one (defensive; Doxygen doesn't currently emit one).

## Local smoke

Ran the mirror block against a synthetic 2-file tree (one root, one nested under \`apis/foo/\`):

\`\`\`
Mirrored 2 files
--- manifest ---
_foo.html
apis/foo/_bar.html
--- gh-pages/_foo.html ---
<!DOCTYPE html>
<html><head>
  <base href="/documentation/4.5/">
  <link rel="canonical" href="/documentation/_foo.html">
<title>Foo</title>
...
--- gh-pages/apis/foo/_bar.html ---
<!DOCTYPE html>
<html><head>
  <base href="/documentation/4.5/">
  <link rel="canonical" href="/documentation/apis/foo/_bar.html">...
\`\`\`

## Companion website change needed

This PR is necessary but not sufficient. The website's \`ProxyHandler.HtmlProcessContext\` currently 308-redirects any \`/documentation/_*.html\` path that doesn't contain a version segment, **regardless** of whether upstream returned 200. That branch becomes unreachable / wrong once the mirror exists.

I'll open a small follow-up PR on the website repo to drop the \`if (version != null) { fetch+serve } else { 308 }\` wrapper and unconditionally fetch+serve. Combined diff there is ~10 lines.

**Ship order**: this PR first (and run \`Build Documentation\` to publish the mirror), then the website PR. The mirror existing without the website change is a no-op (still 308s); the website change without the mirror would 404 unversioned URLs.

## Storage impact

Mirrors are HTML only (no CSS / JS / image duplication). Doxygen produces ~200-400 HTML files per docs version; each is ~10-50 KB. Net new gh-pages content: roughly 5-15 MB. GH Pages soft limit is 1 GB; comfortably under.

## Test plan

- [ ] Manually trigger \`Build Documentation\` workflow on this branch and confirm gh-pages preview/branch has unversioned mirrors at the root.
- [ ] Spot-check one mirrored file in DevTools: \`<base>\` and canonical tags present, assets load from the versioned path, internal nav links resolve to versioned URLs.
- [ ] After the companion website PR ships: confirm \`https://51degrees.com/documentation/_device_detection__quickstart.html\` returns 200 directly (Network tab shows no 308 hop).
- [ ] After deploy + Semrush re-crawl: confirm defect 214 count drops to near zero.