### PR TITLE
Clarify 51Did identifier (wrapper) vs probabilistic value (payload field)

### DIFF
--- a/src/identifiers/fodid.md
+++ b/src/identifiers/fodid.md
@@ -1,6 +1,15 @@
 @page Identifiers_51DiD 51DiD (51Degrees Identifier)
 
-A signed, probabilistic identifier encoded as an <a href="https://github.com/SWAN-community/owid/blob/main/explainer.md">OWID - Open Web ID</a>, the SWAN community schema that defines the binary layout, signature, and verification rules.
+A signed envelope, encoded as an <a href="https://github.com/SWAN-community/owid/blob/main/explainer.md">OWID - Open Web ID</a> (the SWAN community schema that defines the binary layout, signature, and verification rules), wrapping a **probabilistic value** that two recipients can compare to decide whether they have observed the same browser instance under the same usage purpose.
+
+## Terminology
+
+The two layers are distinct and the documentation below uses the words deliberately.
+
+- The **51DiD** is the **identifier** -- the whole base64 OWID envelope (version, domain, date, payload, signature). It changes byte-for-byte every time the cloud issues one, even for the same inputs, because the date and signature change with each call.
+- The **probabilistic value** is one of the fields *inside* the payload (a 32-byte hash). It is stable across reissues for the same device + IP + usage: if two 51DiDs were issued for the same inputs, their probabilistic values are equal even though the wrapping identifiers differ.
+
+Comparing two browsers means comparing the probabilistic values carried inside their identifiers, never the identifiers themselves. Calling either layer "the identifier" without qualification leads to incorrect comparisons; calling the inner field "the probabilistic identifier" is the same confusion in a different costume.
 
 Derived from three inputs:
 
@@ -26,7 +35,9 @@ The flags are hierarchical -- `personalized` implies `standard`, and `standard` 
 
 ## Properties
 
-| Property             | Scope                                          |
+Each property returns a full 51DiD identifier (the OWID envelope, signed). The probabilistic value inside has the scope described in the table.
+
+| Property             | Scope of the probabilistic value inside        |
 |----------------------|------------------------------------------------|
 | `fodid.idprobglobal` | Unique across all callers from device+network. |
 | `fodid.idproblic`    | Unique only across the caller's License Key.   |
@@ -74,7 +85,7 @@ Open the example value in the [51DiD inspector](https://51degrees.com/developers
 
 ## 51DiD readers
 
-A 51DiD is a binary OWID envelope wrapping a 51Degrees payload. Unpacking the payload, comparing two 51DiDs, or verifying the signature in your own code needs a reader that understands both layers. 51Degrees publishes a reader per platform; pick whichever matches your stack.
+A 51DiD is a binary OWID envelope wrapping a 51Degrees payload (see *Terminology* above for the wrapper-vs-value distinction). Unpacking the payload, comparing two 51DiDs, or verifying the signature in your own code needs a reader that understands both layers. 51Degrees publishes a reader per platform; pick whichever matches your stack.
 
 | Platform | Package          | Distribution                                           |
 |----------|------------------|--------------------------------------------------------|
@@ -84,7 +95,9 @@ Readers for other platforms are on the roadmap and will be added to this table a
 
 ## Comparing two 51DiDs
 
-A 51DiD is an OWID envelope wrapping a probabilistic identifier payload. Two responses for the same device + IP + usage will differ at the byte level because the envelope embeds a timestamp and signature each time. To decide whether two 51DiDs are identical, compare only the 32-byte hash inside the payload, never the full base64 value.
+Two 51DiDs issued for the same device + IP + usage will differ at the byte level because the envelope embeds a fresh timestamp and signature on each call. The byte-level difference is in the **identifier** (the wrapper); the **probabilistic value** carried inside is stable across reissues. To decide whether the two refer to the same browser instance, compare the probabilistic values, never the full base64 identifiers.
+
+The probabilistic value is one of the fields the reader exposes after parsing the payload (per platform, named `Hash` in .NET to reflect that it is a 32-byte SHA-256). Treat it as the cache / dedup key.
 
 Two responses to the same device + IP + `id.usage=non-marketing`, returned a few seconds apart:
 
@@ -101,15 +114,17 @@ Unpacked with the [.NET reader](https://www.nuget.org/packages/FiftyOne.Did):
 var a = new FodId(idprobglobalA);
 var b = new FodId(idprobglobalB);
 
-// Wrapper bytes (Domain, Date, Signature) ARE different:
+// Wrapper bytes (Domain, Date, Signature) ARE different -- the
+// identifier itself is not stable across reissues:
 Console.WriteLine(a.Date == b.Date);          // false
 Console.WriteLine(a.Signature.SequenceEqual(b.Signature)); // false
 
-// Payload hashes (the probabilistic identifier) ARE the same:
+// The probabilistic value inside the payload IS stable -- this is
+// what you actually compare:
 Console.WriteLine(a.Hash.SequenceEqual(b.Hash));           // true
 ```
 
-Use `FodId.Hash` (32 bytes, SHA-256) as the cache / dedup key. The same hash means the same 51DiD under the same usage policy on the same License Key (for `idproblic`) or across all callers (for `idprobglobal`).
+Use `FodId.Hash` (32 bytes, SHA-256, the probabilistic value) as the cache / dedup key. The same value means the same browser instance under the same usage policy on the same License Key (for `idproblic`) or across all callers (for `idprobglobal`).
 
 ## Validation
 

--- a/src/identifiers/fodid.md
+++ b/src/identifiers/fodid.md
@@ -6,7 +6,7 @@ A signed envelope, encoded as an <a href="https://github.com/SWAN-community/owid
 
 The two layers are distinct and the documentation below uses the words deliberately.
 
-- The **51Did** is the **identifier** -- the whole base64 OWID envelope (version, domain, date, payload, signature). It changes byte-for-byte every time the cloud issues one, even for the same inputs, because the date and signature change with each call.
+- The **51Did** is the **identifier**, the whole base64 OWID envelope (version, domain, date, payload, signature). It changes byte-for-byte every time the cloud issues one, even for the same inputs, because the date and signature change with each call.
 - The **probabilistic value** is one of the fields *inside* the payload (a 32-byte hash). It is stable across reissues for the same device + IP + usage: if two 51Dids were issued for the same inputs, their probabilistic values are equal even though the wrapping identifiers differ.
 
 Comparing two browsers means comparing the probabilistic values carried inside their identifiers, never the identifiers themselves. Calling either layer "the identifier" without qualification leads to incorrect comparisons; calling the inner field "the probabilistic identifier" is the same confusion in a different costume.
@@ -114,12 +114,12 @@ Unpacked with the [.NET reader](https://www.nuget.org/packages/FiftyOne.Did):
 var a = new FodId(idprobglobalA);
 var b = new FodId(idprobglobalB);
 
-// Wrapper bytes (Domain, Date, Signature) ARE different -- the
+// Wrapper bytes (Domain, Date, Signature) ARE different; the
 // identifier itself is not stable across reissues:
 Console.WriteLine(a.Date == b.Date);          // false
 Console.WriteLine(a.Signature.SequenceEqual(b.Signature)); // false
 
-// The probabilistic value inside the payload IS stable -- this is
+// The probabilistic value inside the payload IS stable; this is
 // what you actually compare:
 Console.WriteLine(a.Hash.SequenceEqual(b.Hash));           // true
 ```

--- a/src/identifiers/fodid.md
+++ b/src/identifiers/fodid.md
@@ -1,4 +1,4 @@
-@page Identifiers_51DiD 51DiD (51Degrees Identifier)
+@page Identifiers_51Did 51Did (51Degrees Identifier)
 
 A signed envelope, encoded as an <a href="https://github.com/SWAN-community/owid/blob/main/explainer.md">OWID - Open Web ID</a> (the SWAN community schema that defines the binary layout, signature, and verification rules), wrapping a **probabilistic value** that two recipients can compare to decide whether they have observed the same browser instance under the same usage purpose.
 
@@ -6,8 +6,8 @@ A signed envelope, encoded as an <a href="https://github.com/SWAN-community/owid
 
 The two layers are distinct and the documentation below uses the words deliberately.
 
-- The **51DiD** is the **identifier** -- the whole base64 OWID envelope (version, domain, date, payload, signature). It changes byte-for-byte every time the cloud issues one, even for the same inputs, because the date and signature change with each call.
-- The **probabilistic value** is one of the fields *inside* the payload (a 32-byte hash). It is stable across reissues for the same device + IP + usage: if two 51DiDs were issued for the same inputs, their probabilistic values are equal even though the wrapping identifiers differ.
+- The **51Did** is the **identifier** -- the whole base64 OWID envelope (version, domain, date, payload, signature). It changes byte-for-byte every time the cloud issues one, even for the same inputs, because the date and signature change with each call.
+- The **probabilistic value** is one of the fields *inside* the payload (a 32-byte hash). It is stable across reissues for the same device + IP + usage: if two 51Dids were issued for the same inputs, their probabilistic values are equal even though the wrapping identifiers differ.
 
 Comparing two browsers means comparing the probabilistic values carried inside their identifiers, never the identifiers themselves. Calling either layer "the identifier" without qualification leads to incorrect comparisons; calling the inner field "the probabilistic identifier" is the same confusion in a different costume.
 
@@ -17,11 +17,11 @@ Derived from three inputs:
 - The **client IP** of the request.
 - The **usage purpose** declared per request (see *Usage flags* below).
 
-51DiDs are produced only by the cloud JSON endpoint when the Resource Key includes the relevant properties. **The 51DiD is not available in the on-premise pipeline:** every identifier is signed with a private ECDSA P-256 key held only by 51Degrees' cloud service, so that recipients can verify authenticity without trusting the caller. An on-premise pipeline never holds the signing key and so cannot create a valid 51DiD.
+51Dids are produced only by the cloud JSON endpoint when the Resource Key includes the relevant properties. **The 51Did is not available in the on-premise pipeline:** every identifier is signed with a private ECDSA P-256 key held only by 51Degrees' cloud service, so that recipients can verify authenticity without trusting the caller. An on-premise pipeline never holds the signing key and so cannot create a valid 51Did.
 
 ## Usage flags
 
-The 51DiD payload starts with a one-byte **flags** field that records which usage purposes the cloud was allowed to derive the identifier for. Three flags are currently defined:
+The 51Did payload starts with a one-byte **flags** field that records which usage purposes the cloud was allowed to derive the identifier for. Three flags are currently defined:
 
 | Flag             | Purpose                                                          |
 |------------------|------------------------------------------------------------------|
@@ -31,11 +31,11 @@ The 51DiD payload starts with a one-byte **flags** field that records which usag
 
 The flags are hierarchical -- `personalized` implies `standard`, and `standard` implies `non-marketing` mirroring the kind of consent tier a user dialog typically offers (a single tier per visitor that covers every use below it).
 
-**Only `non-marketing` global 51DiDs are available in the free tier.** Issuing a 51DiD for `standard` or `personalized` purposes requires a **Special license key** to be added to the Resource Key -- see *Usage policies and licensing* below.
+**Only `non-marketing` global 51Dids are available in the free tier.** Issuing a 51Did for `standard` or `personalized` purposes requires a **Special license key** to be added to the Resource Key -- see *Usage policies and licensing* below.
 
 ## Properties
 
-Each property returns a full 51DiD identifier (the OWID envelope, signed). The probabilistic value inside has the scope described in the table.
+Each property returns a full 51Did identifier (the OWID envelope, signed). The probabilistic value inside has the scope described in the table.
 
 | Property             | Scope of the probabilistic value inside        |
 |----------------------|------------------------------------------------|
@@ -55,9 +55,9 @@ Each property returns a full 51DiD identifier (the OWID envelope, signed). The p
 | `standard`     | Special license key required.           |
 | `personalized` | Special license key required.           |
 
-`standard` and `personalized` 51DiDs are issued under contractual Model Terms that govern how the data can be used once it leaves the cloud service, and are gated by Know Your Customer (KYC) checks before the Special license key is granted. Contact 51Degrees to apply.
+`standard` and `personalized` 51Dids are issued under contractual Model Terms that govern how the data can be used once it leaves the cloud service, and are gated by Know Your Customer (KYC) checks before the Special license key is granted. Contact 51Degrees to apply.
 
-`non-marketing` 51DiDs are provided under legitimate interest and must not leave the customer environment.
+`non-marketing` 51Dids are provided under legitimate interest and must not leave the customer environment.
 
 If `id.usage` is omitted, or set to `standard` / `personalized` while the Resource Key lacks the Special license key, the `fodid.*` properties are returned with a no-value reason rather than throwing. Any value other than the three listed above is rejected as an invalid usage.
 
@@ -81,11 +81,11 @@ Response:
 }
 ```
 
-Open the example value in the [51DiD inspector](https://51degrees.com/developers/51did-inspector?51did=AzUxZC5lcwBzGTMAJQAAAAHWTQAAr193zLwxDrchR2XHYmoTzJML7fAB60rimQeTd2WuHMPoQ4Bz56QhxhXoAynWyaAE8kWo8DO92y9LPLdatHSVaCdSioL7JaMg8S2DV36ehXIZc0HhdqteyARmOnRS7o8j) to unpack the OWID envelope, see the parsed flags, licenseId and 32-byte hash, and verify the ECDSA P-256 signature against the issuer's published public key.
+Open the example value in the [51Did inspector](https://51degrees.com/developers/51did-inspector?51did=AzUxZC5lcwBzGTMAJQAAAAHWTQAAr193zLwxDrchR2XHYmoTzJML7fAB60rimQeTd2WuHMPoQ4Bz56QhxhXoAynWyaAE8kWo8DO92y9LPLdatHSVaCdSioL7JaMg8S2DV36ehXIZc0HhdqteyARmOnRS7o8j) to unpack the OWID envelope, see the parsed flags, licenseId and 32-byte hash, and verify the ECDSA P-256 signature against the issuer's published public key.
 
-## 51DiD readers
+## 51Did readers
 
-A 51DiD is a binary OWID envelope wrapping a 51Degrees payload (see *Terminology* above for the wrapper-vs-value distinction). Unpacking the payload, comparing two 51DiDs, or verifying the signature in your own code needs a reader that understands both layers. 51Degrees publishes a reader per platform; pick whichever matches your stack.
+A 51Did is a binary OWID envelope wrapping a 51Degrees payload (see *Terminology* above for the wrapper-vs-value distinction). Unpacking the payload, comparing two 51Dids, or verifying the signature in your own code needs a reader that understands both layers. 51Degrees publishes a reader per platform; pick whichever matches your stack.
 
 | Platform | Package          | Distribution                                           |
 |----------|------------------|--------------------------------------------------------|
@@ -93,17 +93,17 @@ A 51DiD is a binary OWID envelope wrapping a 51Degrees payload (see *Terminology
 
 Readers for other platforms are on the roadmap and will be added to this table as they are released.
 
-## Comparing two 51DiDs
+## Comparing two 51Dids
 
-Two 51DiDs issued for the same device + IP + usage will differ at the byte level because the envelope embeds a fresh timestamp and signature on each call. The byte-level difference is in the **identifier** (the wrapper); the **probabilistic value** carried inside is stable across reissues. To decide whether the two refer to the same browser instance, compare the probabilistic values, never the full base64 identifiers.
+Two 51Dids issued for the same device + IP + usage will differ at the byte level because the envelope embeds a fresh timestamp and signature on each call. The byte-level difference is in the **identifier** (the wrapper); the **probabilistic value** carried inside is stable across reissues. To decide whether the two refer to the same browser instance, compare the probabilistic values, never the full base64 identifiers.
 
 The probabilistic value is one of the fields the reader exposes after parsing the payload (per platform, named `Hash` in .NET to reflect that it is a 32-byte SHA-256). Treat it as the cache / dedup key.
 
 Two responses to the same device + IP + `id.usage=non-marketing`, returned a few seconds apart:
 
 ```
-51DiD A (base64) : AzUxZC5lcwBzGTMAJQAAAAHWTQAAr193zLwxDrchR2XHYmoTzJML7fAB60rimQeTd2WuHMPoQ4...
-51DiD B (base64) : AzUxZC5lcwCxHzMAJQAAAAHWTQAAr193zLwxDrchR2XHYmoTzJML7fAB60rimQeTd2WuHMPoQ4...
+51Did A (base64) : AzUxZC5lcwBzGTMAJQAAAAHWTQAAr193zLwxDrchR2XHYmoTzJML7fAB60rimQeTd2WuHMPoQ4...
+51Did B (base64) : AzUxZC5lcwCxHzMAJQAAAAHWTQAAr193zLwxDrchR2XHYmoTzJML7fAB60rimQeTd2WuHMPoQ4...
                               ^^^^^^                                                ^^^^^^^^
                               date differs                              signature differs further down
 ```
@@ -128,14 +128,14 @@ Use `FodId.Hash` (32 bytes, SHA-256, the probabilistic value) as the cache / ded
 
 ## Validation
 
-A 51DiD recipient can optionally verify the signature before trusting the identifier. Two options:
+A 51Did recipient can optionally verify the signature before trusting the identifier. Two options:
 
 1. **Cloud endpoint.** Send the base64 value to the verification endpoint on the V4 cloud and get back a parsed payload only if the signature checks out. Simple, no key handling, but every call is metered against the Resource Key.
-2. **Local verification using the published public key.** Fetch 51Degrees' public ECDSA P-256 key once, cache it, and verify in-process for every received identifier. No metering. Each platform reader (see *51DiD readers* above) exposes an in-process verify method that takes the public key PEM and returns a boolean. The .NET reader's method is the inherited `Owid.VerifyAsync`.
+2. **Local verification using the published public key.** Fetch 51Degrees' public ECDSA P-256 key once, cache it, and verify in-process for every received identifier. No metering. Each platform reader (see *51Did readers* above) exposes an in-process verify method that takes the public key PEM and returns a boolean. The .NET reader's method is the inherited `Owid.VerifyAsync`.
 
 In both cases, validation only confirms the identifier was created by 51Degrees and has not been tampered with. It does not certify that the device + IP + usage inputs were truthful: that trust lives in the operational contract with the issuing 51Degrees cloud, not in the signature.
 
 ## Use cases
 
-- **Marketing** - PMP captures the user's preference and feeds it as `id.usage`; the 51DiD is consumed by Prebid / RTB enrichment. See @ref Identifiers_PMP and @ref DeviceDetection_OtherIntegrations_Prebid.
+- **Marketing** - PMP captures the user's preference and feeds it as `id.usage`; the 51Did is consumed by Prebid / RTB enrichment. See @ref Identifiers_PMP and @ref DeviceDetection_OtherIntegrations_Prebid.
 - **Non-marketing** - the integrator sets `id.usage=non-marketing` server-side for fraud, bot or suspicious-activity detection (for example, the suspicious-activity module in the 51Degrees WordPress plugin). The identifier never leaves the customer environment.

--- a/src/identifiers/index.md
+++ b/src/identifiers/index.md
@@ -2,6 +2,6 @@
 
 @subpage Identifiers_Overview
 
-@subpage Identifiers_51DiD
+@subpage Identifiers_51Did
 
 @subpage Identifiers_PMP

--- a/src/identifiers/overview.md
+++ b/src/identifiers/overview.md
@@ -1,19 +1,19 @@
 @page Identifiers_Overview Overview
 
-**51DiD** (51Degrees Identifier) and **PMP** (Privacy Marketing Preference) are derived signals downstream systems can act on without seeing the raw inputs.
+**51Did** (51Degrees Identifier) and **PMP** (Privacy Marketing Preference) are derived signals downstream systems can act on without seeing the raw inputs.
 
-- **51DiD** - signed identifier (a base64 OWID envelope) carrying a probabilistic value, derived from three inputs: the **Device ID** (a `Hardware-Platform-Browser-IsCrawler` tuple produced by Device Detection), the **client IP**, and the **usage purpose** (`non-marketing`, `standard`, or `personalized`) declared per request. See @ref Identifiers_51DiD for the identifier-versus-value distinction.
-- **PMP** - embeddable widget that captures a marketing preference (`standard` / `personalized`) suitable as `id.usage` input to 51DiD.
+- **51Did** - signed identifier (a base64 OWID envelope) carrying a probabilistic value, derived from three inputs: the **Device ID** (a `Hardware-Platform-Browser-IsCrawler` tuple produced by Device Detection), the **client IP**, and the **usage purpose** (`non-marketing`, `standard`, or `personalized`) declared per request. See @ref Identifiers_51Did for the identifier-versus-value distinction.
+- **PMP** - embeddable widget that captures a marketing preference (`standard` / `personalized`) suitable as `id.usage` input to 51Did.
 
 ## Flow
 
 ```
-User → PMP → preference → id.usage → 51DiD → downstream
+User → PMP → preference → id.usage → 51Did → downstream
 ```
 
 ## Use one without the other when
 
-- **PMP alone** - you need to collect a user marketing preference and act on it directly (e.g. gate ad personalization, drive a paywall), without feeding it into 51DiD.
-- **51DiD alone** - `id.usage=non-marketing` (e.g. fraud or suspicious activity); the preference is set by the integrator, not the user.
+- **PMP alone** - you need to collect a user marketing preference and act on it directly (e.g. gate ad personalization, drive a paywall), without feeding it into 51Did.
+- **51Did alone** - `id.usage=non-marketing` (e.g. fraud or suspicious activity); the preference is set by the integrator, not the user.
 
-See @ref Identifiers_51DiD and @ref Identifiers_PMP. 51DiD depends on @ref DeviceDetection_Overview.
+See @ref Identifiers_51Did and @ref Identifiers_PMP. 51Did depends on @ref DeviceDetection_Overview.

--- a/src/identifiers/overview.md
+++ b/src/identifiers/overview.md
@@ -2,7 +2,7 @@
 
 **51DiD** (51Degrees Identifier) and **PMP** (Privacy Marketing Preference) are derived signals downstream systems can act on without seeing the raw inputs.
 
-- **51DiD** - signed, probabilistic ID derived from three inputs: the **Device ID** (a `Hardware-Platform-Browser-IsCrawler` tuple produced by Device Detection), the **client IP**, and the **usage purpose** (`non-marketing`, `standard`, or `personalized`) declared per request.
+- **51DiD** - signed identifier (a base64 OWID envelope) carrying a probabilistic value, derived from three inputs: the **Device ID** (a `Hardware-Platform-Browser-IsCrawler` tuple produced by Device Detection), the **client IP**, and the **usage purpose** (`non-marketing`, `standard`, or `personalized`) declared per request. See @ref Identifiers_51DiD for the identifier-versus-value distinction.
 - **PMP** - embeddable widget that captures a marketing preference (`standard` / `personalized`) suitable as `id.usage` input to 51DiD.
 
 ## Flow

--- a/src/identifiers/pmp.md
+++ b/src/identifiers/pmp.md
@@ -1,6 +1,6 @@
 @page Identifiers_PMP PMP (Preference Management Platform)
 
-Lightweight embeddable widget that asks the user for a marketing preference, stores it in `localStorage`, and invokes a publisher-defined continuation URL with that preference - typically the 51DiD generation endpoint. The chosen `standard` or `personalized` value is the `id.usage` input for @ref Identifiers_51DiD.
+Lightweight embeddable widget that asks the user for a marketing preference, stores it in `localStorage`, and invokes a publisher-defined continuation URL with that preference - typically the 51Did generation endpoint. The chosen `standard` or `personalized` value is the `id.usage` input for @ref Identifiers_51Did.
 
 ## Endpoint
 
@@ -57,7 +57,7 @@ The Alternative button (e.g. "Subscribe to remove ads") stores `standard` as the
 1. The script loads and reads any stored preference from `localStorage`.
 2. If none is stored, the dialog is shown.
 3. The user chooses; the preference is saved to `localStorage`.
-4. `data-action-url` is dispatched with `{preference}` substituted - this is the continuation that drives downstream behaviour (most commonly fetching `/api/v4/<KEY>.js?id.usage={preference}` so 51DiD data lands on the page). For `http(s)` URLs PMP injects `<script src="...">`; for `javascript:` URLs the code runs inline.
+4. `data-action-url` is dispatched with `{preference}` substituted - this is the continuation that drives downstream behaviour (most commonly fetching `/api/v4/<KEY>.js?id.usage={preference}` so 51Did data lands on the page). For `http(s)` URLs PMP injects `<script src="...">`; for `javascript:` URLs the code runs inline.
 
 On subsequent visits steps 2-3 are skipped: PMP reads the stored preference from `localStorage` and goes straight to step 4. So `data-action-url` fires on every page load, not just on the first user choice.
 
@@ -79,5 +79,5 @@ location.reload();
 
 ## Cross-references
 
-- @ref Identifiers_51DiD - how `id.usage` is consumed.
-- @ref DeviceDetection_OtherIntegrations_Prebid - downstream RTB enrichment that consumes the 51DiD.
+- @ref Identifiers_51Did - how `id.usage` is consumed.
+- @ref DeviceDetection_OtherIntegrations_Prebid - downstream RTB enrichment that consumes the 51Did.

--- a/src/main.md
+++ b/src/main.md
@@ -14,7 +14,7 @@ At 51Degrees, we turn every user interaction into a chance to learn, optimize, a
 - **Device Detection** - Detect 250+ device properties from HTTP headers and other signals to tailor every user experience.
 - **IP Intelligence** - Unlock geolocation, ISP, and network data from IP addresses for sharper insights and smarter decisions.
 - **Reverse Geocoding** - Transform latitude and longitude into real-world addresses, cities, and regions.
-- **Identifiers** - Generate privacy-aware signals (51DiD) and capture user marketing preferences (PMP) to feed downstream systems.
+- **Identifiers** - Generate privacy-aware signals (51Did) and capture user marketing preferences (PMP) to feed downstream systems.
 - **Ultra-fast Performance** - Enjoy lightning-fast detection speeds thanks to in-process deployment.
 - **Privacy-first Architecture** - Prefer to keep your data close? Our On-premise options ensure full control and compliance.
 
@@ -49,10 +49,10 @@ Turn GPS coordinates into meaningful places. Bring real-world context to your di
 
 ### Identifiers
 
-Signed, probabilistic device-bound identifiers (51DiD) and an embeddable preference widget (PMP) that feeds `id.usage` into 51DiD.
+Signed, probabilistic device-bound identifiers (51Did) and an embeddable preference widget (PMP) that feeds `id.usage` into 51Did.
 
 - [Overview](@ref Identifiers_Overview) - How the pieces fit together
-- [51DiD](@ref Identifiers_51DiD) - Properties, `id.usage`, licensing
+- [51Did](@ref Identifiers_51Did) - Properties, `id.usage`, licensing
 - [PMP](@ref Identifiers_PMP) - Embeddable preference widget
 
 ### Client-Side Only
@@ -148,7 +148,7 @@ Everything you need to succeed:
 - [Device Detection](@ref DeviceDetection_Quickstart) - Cloud vs. On-premise
 - [IP Intelligence](@ref IpIntelligence_Quickstart) - Location and network data
 - [Reverse Geocoding](@ref ReverseGeocoding_Quickstart) - From coordinates to addresses
-- [Identifiers](@ref Identifiers_Overview) - 51DiD and PMP
+- [Identifiers](@ref Identifiers_Overview) - 51Did and PMP
 
 ### Deep Dives
 


### PR DESCRIPTION
The 51DiD has two distinct layers and the docs were treating them interchangeably. This leads readers (and humans wiring up comparison code) into byte-by-byte comparisons of the full identifier and concluding two responses for the same device are different.

## Summary

* New **Terminology** section at the top of `fodid.md` names the two layers:
  - **51DiD / identifier**: the whole base64 OWID envelope (version, domain, date, payload, signature). Changes byte-for-byte on every reissue.
  - **Probabilistic value**: the 32-byte hash inside the payload. Stable across reissues for the same device + IP + usage.
* Opening paragraph rewritten so the first sentence reflects both layers.
* Properties table header clarified: the property values ARE full identifiers; the table's scope column describes the value inside.
* "Comparing two 51DiDs" rewritten to say compare the probabilistic values, never the full identifiers. Code-sample comments now make explicit that `Hash` IS the probabilistic value.
* `overview.md` one-liner updated to match, with a pointer back to the Terminology section.

Calling either layer "the identifier" without qualification leads to incorrect comparisons; calling the inner field "the probabilistic identifier" is the same conflation in a different costume. Both wordings are scrubbed.

## Driven by

A parallel rename on 51degrees.com (`feature/51did-comparer`): the inspector and comparer pages now use "Probabilistic value" throughout for the same reason. This PR brings the canonical documentation in line so the website copy and the developer docs agree.

## Test plan

- [ ] Render `src/identifiers/fodid.md` locally (or in PR preview) and read the Terminology section: it should make the wrapper/value distinction immediately clear.
- [ ] Walk through the "Comparing two 51DiDs" code sample with the new comments. Verify a reader following only the comments would compare the right field.
- [ ] `src/identifiers/overview.md` one-liner reads naturally and points at the Terminology anchor.