### PR TITLE
CI: HTML content validator (alt-attribute check) - closes #151

### DIFF
--- a/ci/generate-documentation.ps1
+++ b/ci/generate-documentation.ps1
@@ -101,3 +101,12 @@ Get-ChildItem -Recurse -File -Filter "*.html" -Path "gh-pages/$version" | ForEac
 Set-Content -Path $manifestPath -Value ($mirrored -join "`n")
 Write-Host "Mirrored $($mirrored.Count) HTML files to gh-pages root."
 Write-Host "::endgroup::"
+
+# Scan the freshly generated HTML for content-quality regressions
+# before it gets published. Companion to the Website-side
+# ContentValidator (postbuild/ContentValidator.cs); see
+# 51Degrees/documentation issue #151 for context. Warns only at the
+# moment; flip -FailOnFinding $true once the count is genuinely zero.
+Write-Host "::group::Validating generated HTML"
+& "$PSScriptRoot/validate-html.ps1" -Path "gh-pages/$version"
+Write-Host "::endgroup::"

--- a/ci/validate-html.ps1
+++ b/ci/validate-html.ps1
@@ -1,0 +1,89 @@
+# Ignore Spelling: ci
+
+<#
+.SYNOPSIS
+    Walks the generated HTML under -Path and warns about content-quality
+    issues. Companion to the Website-side ContentValidator
+    (postbuild/ContentValidator.cs in 51Degrees/Website), filed against
+    51Degrees/documentation issue #151.
+
+.DESCRIPTION
+    Currently scans for one Semrush-rule-117 case: an <img> element with
+    no alt attribute at all. An explicit alt="" is the WCAG-correct
+    marking for a purely decorative image (screen readers skip it), so we
+    flag only the absent-attribute form, never the empty-value form.
+    Imgs with no src are also skipped: those are lazy-loaded placeholders
+    or template stubs whose real img is populated later.
+
+    Logged as warnings by default; pass -FailOnFinding to gate the build
+    on a non-zero count. Default-warn matches the Website-side behaviour
+    so we can watch the trend on a real build before adding teeth.
+
+.PARAMETER Path
+    Root directory to walk recursively for *.html.
+
+.PARAMETER MaxIssuesLogged
+    Cap on individual issue lines emitted, so a regression on a large
+    page set doesn't flood the build log. Defaults to 200.
+
+.PARAMETER FailOnFinding
+    When $true, exits non-zero if any issues are found. Default $false.
+#>
+param(
+    [Parameter(Mandatory)][string]$Path,
+    [int]$MaxIssuesLogged = 200,
+    [switch]$FailOnFinding
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 3.0
+
+if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+    throw "validate-html.ps1: -Path '$Path' is not a directory"
+}
+
+$root = (Resolve-Path -LiteralPath $Path).Path
+$files = Get-ChildItem -Recurse -File -Filter "*.html" -LiteralPath $root
+$pagesScanned = 0
+$issues = [System.Collections.Generic.List[string]]::new()
+
+# Doxygen's HTML never spans an <img> tag across multiple lines, so a
+# single-line regex is sufficient. The Website-side validator uses
+# HtmlAgilityPack for the same job; ps1 stays leaner without it.
+$imgRe = [regex]'<img\b[^>]*?>'
+
+foreach ($f in $files) {
+    $pagesScanned++
+    # GetRelativePath normalises across short (DOS 8.3) vs. long path
+    # spellings, which Substring on FullName cannot.
+    $rel = [System.IO.Path]::GetRelativePath($root, $f.FullName) `
+        -replace '\\','/'
+    $content = Get-Content -Raw -LiteralPath $f.FullName
+    foreach ($m in $imgRe.Matches($content)) {
+        $tag = $m.Value
+        # Has an alt attribute (even alt="") - the WCAG-correct form, not
+        # a finding. Only the absent-attribute case fires.
+        if ($tag -match '\balt\s*=') { continue }
+        # No src either - lazy-loaded placeholder or template stub, skip.
+        if ($tag -notmatch '\bsrc\s*=') { continue }
+        $issues.Add("IMG-ALT /$rel : $tag")
+    }
+}
+
+Write-Host ("HtmlValidator: scanned {0} pages, {1} content issues found" -f `
+    $pagesScanned, $issues.Count)
+
+$logged = 0
+foreach ($issue in $issues) {
+    if ($logged -ge $MaxIssuesLogged) { break }
+    Write-Warning "HtmlValidator: $issue"
+    $logged++
+}
+if ($issues.Count -gt $MaxIssuesLogged) {
+    Write-Warning ("HtmlValidator: ...and {0} more (suppressed; raise " +
+        "-MaxIssuesLogged to see all)" -f ($issues.Count - $MaxIssuesLogged))
+}
+
+if ($FailOnFinding.IsPresent -and $issues.Count -gt 0) {
+    throw "HtmlValidator: $($issues.Count) findings, build gated by -FailOnFinding."
+}


### PR DESCRIPTION
## Summary

Closes #151.

Adds a build-time HTML content validator that runs at the end of `ci/generate-documentation.ps1` and warns on `<img>` elements that have no `alt` attribute (Semrush rule 117). Mirrors the equivalent tripwire shipped on the Website side in [51Degrees/Website#573](https://github.com/51Degrees/Website/pull/573) (`postbuild/ContentValidator.cs`), so both sides catch the same class of regression locally at build time instead of waiting days for the next Semrush audit.

## Semantics

Intentionally the same as the Website-side validator:

| `<img>` shape | Action | Why |
|---|---|---|
| `<img src=... alt="...">` | pass | descriptive alt, fine |
| `<img src=... alt="">` | pass | the WCAG-correct marking for purely decorative images (screen readers skip them) - and what Semrush rule 117 also passes |
| `<img src=...>` (no `alt` attribute) | **flag** | what Semrush rule 117 fires on; assistive tech falls back to reading the file name |
| `<img>` (no `src`) | skip | lazy-loaded placeholder or template stub, real `src` filled in later by JS - can't evaluate from a static scan |

Pre-#573 the Website validator treated `alt=""` as a finding, which drowned the build log in false positives for every decorative icon. This validator avoids that mistake from day one.

## Wiring

- New file `ci/validate-html.ps1` does the scan. Parameters: `-Path` (required), `-MaxIssuesLogged` (default 200), `-FailOnFinding` (switch, default off so warnings don't break the build while we settle the baseline).
- `ci/generate-documentation.ps1` calls it as a final step, right after the unversioned-root mirror (`cb58bc34`) finishes, against `gh-pages/$version/`. Only the canonical versioned tree needs scanning: the mirror copies HTML verbatim plus a `<base>` and a `<link rel=canonical>`, so any img-level finding originates in the versioned source.

Once we see a real build come back clean, flipping `-FailOnFinding` to gate the build is a one-line follow-up.

## Local verification

Smoke-tested against five Semrush-flagged URLs pulled from production (the same sample documented in #151):

```
$ pwsh ci/validate-html.ps1 -Path /tmp/docs-gh-pages-sample
HtmlValidator: scanned 5 pages, 0 content issues found
```

Then injected an intentionally bad file to confirm detection and gating:

```html
<img src="/img/ok.png" alt="">                  <!-- decorative, ignored -->
<img src="/img/also-ok.png" alt="A descriptive"><!-- ignored -->
<img src="/img/lazy.png">                       <!-- FLAGGED: no alt -->
<img>                                           <!-- ignored: no src -->
```

```
$ pwsh ci/validate-html.ps1 -Path /tmp/docs-gh-pages-sample
HtmlValidator: scanned 6 pages, 1 content issues found
WARNING: HtmlValidator: IMG-ALT /bad-test.html : <img src="/img/lazy.png">
exit 0

$ pwsh ci/validate-html.ps1 -Path /tmp/docs-gh-pages-sample -FailOnFinding
HtmlValidator: scanned 6 pages, 1 content issues found
WARNING: HtmlValidator: IMG-ALT /bad-test.html : <img src="/img/lazy.png">
HtmlValidator: 1 findings, build gated by -FailOnFinding.
exit 1
```

Confirms: alt="" passes, src-less placeholder ignored, real missing-alt flagged, and the gate behaves under `-FailOnFinding`.

## Test plan

- [ ] CI green
- [ ] Next nightly `build.yml` run prints the `HtmlValidator: scanned <N> pages, <issues> content issues found` line in the "Validating generated HTML" group
- [ ] The Semrush re-audit triggered alongside #151 (snapshot `6a13f46d90669b53ff116feb`) shows rule 117 at zero or near-zero on the next snapshot, retiring the 182-page stale finding - the validator running in CI from here on will catch any recurrence within hours instead of days