### PR TITLE
CI: flip validate-html.ps1 -FailOnFinding now that baseline is zero

### DIFF
--- a/ci/generate-documentation.ps1
+++ b/ci/generate-documentation.ps1
@@ -105,8 +105,11 @@ Write-Host "::endgroup::"
 # Scan the freshly generated HTML for content-quality regressions
 # before it gets published. Companion to the Website-side
 # ContentValidator (postbuild/ContentValidator.cs); see
-# 51Degrees/documentation issue #151 for context. Warns only at the
-# moment; flip -FailOnFinding $true once the count is genuinely zero.
+# 51Degrees/documentation issue #151 for context. The 2026-05-25
+# scheduled build ran clean ("scanned 5150 pages, 0 content issues
+# found"), so the baseline is genuinely zero -- run with
+# -FailOnFinding from here on to break the build on any regression
+# rather than waiting for someone to spot the warning in the log.
 Write-Host "::group::Validating generated HTML"
-& "$PSScriptRoot/validate-html.ps1" -Path "gh-pages/$version"
+& "$PSScriptRoot/validate-html.ps1" -Path "gh-pages/$version" -FailOnFinding
 Write-Host "::endgroup::"


### PR DESCRIPTION
## Summary

Add `-FailOnFinding` to the `ci/validate-html.ps1` call in `ci/generate-documentation.ps1`. The 2026-05-25 scheduled build ran clean -- `HtmlValidator: scanned 5150 pages, 0 content issues found` -- so the baseline is genuinely zero. Warning-only mode no longer earns its keep: any future regression that adds a missing-alt img would sit in the build log until someone happened to read it. With `-FailOnFinding`, the scheduled build.yml goes red instead, the deploy doesn't push to gh-pages, and the change gets reverted or template-patched the same day.

## Why this is safe now

- Last scheduled run printed 0 issues across all 5,150 generated HTML files
- The validator's semantics are conservative: only an absent `alt` attribute fires (empty `alt=""` is intentional decorative marking and passes; imgs with no `src` are lazy-loaded placeholders and pass)
- `validate-html.ps1` already supports the switch; this PR is the configuration flip, no script logic changes

## Test plan

- [ ] CI green
- [ ] Tonight's 04:00 UTC scheduled build still passes
- [ ] If a future Doxygen template change introduces a missing-alt img, build.yml goes red and the offending file is listed in the "Validating generated HTML" step

## Related

- [`51Degrees/Website#578`](https://github.com/51Degrees/Website/pull/578) -- companion website-side tripwire moved to top of pipeline so slot-swap probes don't render Razor.
- `51Degrees/operations` PRs #12 (/health probe) and #13 (state guard) -- the operations-side halves of the same 2026-05-25 release incident.