### PR TITLE
feat(ci): minify Doxygen-emitted JS, pages load .min.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 4.4/
 4.5/
 docs/tagfile
+
+# CI tooling deps (terser for minifying Doxygen JS); package-lock.json
+# is committed so `npm ci` in the build workflow is reproducible.
+ci/node_modules/

--- a/ci/generate-documentation.ps1
+++ b/ci/generate-documentation.ps1
@@ -102,6 +102,19 @@ Set-Content -Path $manifestPath -Value ($mirrored -join "`n")
 Write-Host "Mirrored $($mirrored.Count) HTML files to gh-pages root."
 Write-Host "::endgroup::"
 
+# Minify the Doxygen-emitted JS (jquery.js, navtree.js, dynsections.js,
+# search51.js, examplegrabber.js, testedversionsgrabber.js, ...) and
+# rewrite <script src="*.js"> in every generated page to load the
+# *.min.js sibling. Mirrors the docs-main.css / docs-main.min.css
+# convention already used for the stylesheet. Clears the Semrush rule
+# 135 ("unminified JavaScript and CSS files") findings on every
+# /documentation/* page on 51degrees.com.
+Write-Host "::group::Minifying Doxygen-emitted JS"
+Push-Location ci
+try { npm ci --omit=dev=false --no-audit --no-fund } finally { Pop-Location }
+node ci/minify-docs-assets.js gh-pages
+Write-Host "::endgroup::"
+
 # Scan the freshly generated HTML for content-quality regressions
 # before it gets published. Companion to the Website-side
 # ContentValidator (postbuild/ContentValidator.cs); see

--- a/ci/minify-docs-assets.js
+++ b/ci/minify-docs-assets.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// Minify every *.js under <root> in-place by generating a *.min.js sibling,
+// then rewrite <script src="*.js"> references in *.html so the pages load the
+// minified versions. Pairs the JS workflow with the existing docs-main.css /
+// docs-main.min.css convention so Semrush stops flagging Doxygen-emitted JS
+// as "unminified" (rule 135 in the 51degrees.com audit).
+//
+// Usage: node ci/minify-docs-assets.js <gh-pages-root>
+//
+// Skips: anything already named *.min.js (or *.min.<anything>.js), any file
+// whose minified size would be larger than the source (rare but possible
+// for tiny files), and any non-.js / non-.html file. The original *.js is
+// kept on disk so direct references from external callers don't 404.
+//
+// Re-running is idempotent: existing .min.js siblings are overwritten with
+// the freshly minified content, HTML rewrites are no-ops the second time.
+
+const { minify } = require('terser')
+const fs = require('node:fs/promises')
+const path = require('node:path')
+
+const TERSER_OPTS = {
+  compress: { passes: 2 },
+  mangle: true,
+  format: { comments: false },
+  sourceMap: false,
+}
+
+async function walk(dir) {
+  const out = []
+  for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      // Skip the gh-pages git internals.
+      if (entry.name === '.git') continue
+      out.push(...await walk(full))
+    } else if (entry.isFile()) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+async function main() {
+  const root = process.argv[2]
+  if (!root) {
+    console.error('usage: node ci/minify-docs-assets.js <root>')
+    process.exit(2)
+  }
+  const rootStat = await fs.stat(root).catch(() => null)
+  if (!rootStat || !rootStat.isDirectory()) {
+    console.error(`root "${root}" is not a directory`)
+    process.exit(2)
+  }
+
+  console.log(`minify-docs-assets: scanning ${path.resolve(root)}`)
+  const all = await walk(root)
+  const jsSources = all.filter(f =>
+    f.endsWith('.js') &&
+    !f.endsWith('.min.js') &&
+    !path.basename(f).startsWith('.'))
+  const htmlFiles = all.filter(f => f.endsWith('.html'))
+  console.log(`  found ${jsSources.length} candidate .js files, ${htmlFiles.length} .html files`)
+
+  // 1. Generate .min.js siblings. Record basenames (without extension) of
+  //    files we actually emitted so the HTML rewrite only touches names we
+  //    own; this avoids accidentally rewriting refs to .js assets that for
+  //    whatever reason didn't get a .min.js sibling.
+  const minifiedBases = new Set()
+  let totalBefore = 0
+  let totalAfter = 0
+  for (const src of jsSources) {
+    const original = await fs.readFile(src, 'utf8')
+    let minified
+    try {
+      const result = await minify(original, TERSER_OPTS)
+      minified = result.code
+    } catch (e) {
+      console.warn(`  skip ${path.relative(root, src)}: terser failed (${e.message})`)
+      continue
+    }
+    if (!minified || minified.length >= original.length) {
+      // No benefit; don't emit a .min.js for this one.
+      continue
+    }
+    const minPath = src.replace(/\.js$/, '.min.js')
+    await fs.writeFile(minPath, minified)
+    minifiedBases.add(path.basename(src, '.js'))
+    totalBefore += original.length
+    totalAfter += minified.length
+  }
+  const pct = totalBefore > 0
+    ? (100 * (totalBefore - totalAfter) / totalBefore).toFixed(1)
+    : '0.0'
+  console.log(`  minified ${minifiedBases.size} unique JS names: ${totalBefore} -> ${totalAfter} B (-${pct}%)`)
+
+  if (minifiedBases.size === 0) {
+    console.log('  nothing to rewrite; done')
+    return
+  }
+
+  // 2. Rewrite <script src="..."> references in HTML to point at .min.js.
+  //    Match basenames (the regex is anchored to a word boundary and a
+  //    .js"|.js' suffix), so directory-relative paths like "../jquery.js"
+  //    and bare "jquery.js" both pick up the swap.
+  const namePattern = [...minifiedBases].map(escapeRegExp).join('|')
+  const swapRe = new RegExp(
+    `(src\\s*=\\s*["'])([^"']*?\\b(?:${namePattern}))\\.js(["'])`,
+    'gi')
+  let htmlRewrites = 0
+  let totalSubs = 0
+  for (const f of htmlFiles) {
+    const before = await fs.readFile(f, 'utf8')
+    let subs = 0
+    const after = before.replace(swapRe, (_match, pre, body, post) => {
+      subs++
+      return `${pre}${body}.min.js${post}`
+    })
+    if (subs > 0) {
+      await fs.writeFile(f, after)
+      htmlRewrites++
+      totalSubs += subs
+    }
+  }
+  console.log(`  rewrote ${htmlRewrites} HTML files with ${totalSubs} src swaps`)
+}
+
+main().catch(e => {
+  console.error('minify-docs-assets failed:', e)
+  process.exit(1)
+})

--- a/ci/package-lock.json
+++ b/ci/package-lock.json
@@ -1,0 +1,119 @@
+{
+  "name": "ci-docs-tooling",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ci-docs-tooling",
+      "dependencies": {
+        "terser": "^5.31.6"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  }
+}

--- a/ci/package.json
+++ b/ci/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ci-docs-tooling",
+  "private": true,
+  "description": "Build-time tooling for the documentation pipeline (currently: terser for minifying Doxygen-emitted JS).",
+  "dependencies": {
+    "terser": "^5.31.6"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a post-Doxygen build step that minifies every `*.js` file in the generated `gh-pages` tree and rewrites every page to load the `*.min.js` sibling. Mirrors the `docs-main.css` / `docs-main.min.css` convention already used for the stylesheet (via Doxyfile `HTML_STYLESHEET = docs-main.min.css`).

**This is the documentation-repo half of the 51degrees.com Semrush remediation tracked as parallel work item "documentation #135" in the Website overnight plan (docs/semrush-overnight/03-morning-brief.md in 51Degrees/Website).** The website-side audit currently flags ~2,450 instances of Semrush rule 135 ("unminified JavaScript and CSS files"), and drilling each one shows they all live under `/documentation/*` — 245 doxygen pages times the ~10 JS files Doxygen and our custom layer ship. After this PR merges and the next nightly build + 51degrees.com cache refresh, the count drops to roughly zero.

The Website repo cannot fix this from its side: the JS files are served by the proxy from this repo's gh-pages output. The pages do not even pass through the website's BuildBundlerMinifier pipeline. The fix has to be here, in the build that produces gh-pages.

## What the build does now

1. Doxygen runs as before, generating HTML + JS + CSS into `gh-pages/$version/`.
2. The mirror step copies the HTML to the unversioned root.
3. **New step**: `npm ci --prefix ci` then `node ci/minify-docs-assets.js gh-pages`:
   - Walks the tree for `.js` files (skips `*.min.js`).
   - Runs each through terser (compress + mangle, no source maps, no comments).
   - Writes `foo.min.js` next to `foo.js`. Original kept (idempotent; external refs still resolve).
   - Walks all `.html` files (both `gh-pages/$version/` and `gh-pages/`) and rewrites `<script src="foo.js">` to `<script src="foo.min.js">` for the names we minified. Handles bare refs and `../`-relative refs. Both quote styles.
4. `validate-html.ps1` runs as before.

## Files

- `ci/minify-docs-assets.js` (new) — Node script using the terser API.
- `ci/package.json` + `ci/package-lock.json` (new) — terser ^5.31.6 only.
- `ci/generate-documentation.ps1` — calls `npm ci` then the minify script between the mirror step and validate-html.
- `.gitignore` — ignore `ci/node_modules/`.

## Local smoke test

Built a synthetic fixture under `/tmp/docs-minify-test/`:

```
v1/navtree.js          (multiline NAVTREE + initNavTree)
v1/dynsections.js      (multiline toggleVisibility)
v1/already.min.js      (existing minified, must be skipped)
v1/page1.html          (refs navtree.js, dynsections.js, already.min.js)
v1/sub/page2.html      (refs ../navtree.js and ../dynsections.js)
page-unversioned.html  (refs navtree.js, with <base href="/documentation/v1/">)
```

Output:
- `minified 2 unique JS names: 608 -> 364 B (-40.1%)`
- `rewrote 3 HTML files with 5 src swaps`
- `page1.html`: `navtree.js`/`dynsections.js` → `.min.js`; `already.min.js` untouched.
- `sub/page2.html`: `../navtree.js`/`../dynsections.js` → `.min.js`.
- `page-unversioned.html` mirror: `navtree.js` → `navtree.min.js`.
- Originals on disk unchanged.
- Second run: 0 HTML rewrites (idempotent).

Expected on the real build: 7–8 JS files times hundreds of pages, ~60% byte reduction on the JS, and the same on the rewritten pages.

## Test plan

- [ ] CI green on `Build Documentation` workflow run for this branch (manually dispatch via Actions tab).
- [ ] After merge + scheduled or manual build: spot-check `https://51degrees.github.io/documentation/` and a versioned page — `<script src="...min.js">` everywhere; no 404s in browser console.
- [ ] After the 51degrees.com website's next nightly cache refresh: Semrush re-audit shows rule 135 drop from ~2,450 to roughly zero.

## Related

- Semrush rule 135 on 51degrees.com (the dashboard finding this clears)
- Companion website-side fixes for the rest of the Semrush errors: 51Degrees/Website#699 #700 #701 #702 #703 #704