### PR TITLE
feat(ci): add root-relative canonical to every versioned doxygen page

### DIFF
--- a/ci/generate-documentation.ps1
+++ b/ci/generate-documentation.ps1
@@ -86,20 +86,45 @@ if (Test-Path $manifestPath) {
 $srcRoot = (Resolve-Path "gh-pages/$version").Path
 $baseTag = "<base href=`"/documentation/$version/`">"
 $mirrored = [System.Collections.Generic.List[string]]::new()
+$canonicalsAdded = 0
 Get-ChildItem -Recurse -File -Filter "*.html" -Path "gh-pages/$version" | ForEach-Object {
     $rel = $_.FullName.Substring($srcRoot.Length + 1) -replace '\\', '/'
     $dest = Join-Path "gh-pages" $rel
     New-Item -ItemType Directory -Force (Split-Path $dest) | Out-Null
     $content = Get-Content $_.FullName -Raw
+
+    # Root-relative canonical pointing at the unversioned URL. Both the
+    # versioned source and the unversioned mirror canonicalise here, so
+    # search engines consolidate equity on /documentation/$rel and the
+    # same rendered HTML is portable across any host (production,
+    # staging, preview, localhost).
     $canonicalTag = "<link rel=`"canonical`" href=`"/documentation/$rel`">"
+
+    # Add canonical to the versioned source in place when it doesn't
+    # already have one (doxygen-generated pages don't ship one). The
+    # site's reverse proxy used to inject this at request time but
+    # pinned the rendered HTML to one host; doing it here once at
+    # build time keeps the output portable. See
+    # 51Degrees/Website#699 for the corresponding proxy-side change.
+    if ($content -notmatch '<link\s+rel=["'']?canonical') {
+        $content = $content -replace '(<head[^>]*>)', "`$1`n  $canonicalTag"
+        Set-Content -Path $_.FullName -Value $content -NoNewline
+        $canonicalsAdded++
+    }
+
+    # Mirror copy under the unversioned root. The mirror adds <base>
+    # so relative refs into versioned assets still resolve, and we
+    # ensure the canonical is present (carried over from the in-place
+    # update above, or copied in here for the rare file that already
+    # had a self-canonical).
     if ($content -notmatch '<base\s') {
-        $content = $content -replace '(<head[^>]*>)', "`$1`n  $baseTag`n  $canonicalTag"
+        $content = $content -replace '(<head[^>]*>)', "`$1`n  $baseTag"
     }
     Set-Content -Path $dest -Value $content -NoNewline
     $mirrored.Add($rel)
 }
 Set-Content -Path $manifestPath -Value ($mirrored -join "`n")
-Write-Host "Mirrored $($mirrored.Count) HTML files to gh-pages root."
+Write-Host "Mirrored $($mirrored.Count) HTML files to gh-pages root, added canonical to $canonicalsAdded versioned files."
 Write-Host "::endgroup::"
 
 # Minify the Doxygen-emitted JS (jquery.js, navtree.js, dynsections.js,


### PR DESCRIPTION
## Summary

The mirror step in `ci/generate-documentation.ps1` already injected a canonical into every unversioned mirror copy (pointing at its own `/documentation/<rel>` URL). Versioned source files (`gh-pages/<version>/...`) were left untouched and had no canonical at all, so:

- 51degrees.com's reverse proxy was injecting one at request time. That worked but pinned the rendered HTML to one host (`https://51degrees.com/...`), and it produced double canonicals on the few pages that already had one.
- Direct GitHub Pages hits (`https://51degrees.github.io/documentation/4.5/...`) had no canonical at all.

This PR extends the mirror loop so the versioned source ALSO gets a root-relative canonical pointing at `/documentation/<rel>` (the unversioned mirror URL). Both forms now canonicalise to the same URL, consolidating SEO equity on the unversioned mirror. The injection is conditional on a canonical not already being present, so anything doxygen ships with its own canonical is left alone.

Resolves #159. Companion of 51Degrees/Website#699 which removes the proxy-side injection.

## Files

- `ci/generate-documentation.ps1` — mirror block extended; same loop now also writes the versioned source.

## Local smoke test

Fixture with four versioned files exercising all paths (root, nested, already-canonical, plain):

```
gh-pages/4.5/index.html              (plain, no canonical)
gh-pages/4.5/_introduction.html      (plain, no canonical)
gh-pages/4.5/apis/foo/bar.html       (nested, no canonical)
gh-pages/4.5/already-canonical.html  (existing canonical to /documentation/already-canonical.html)
```

After running the modified mirror block:

| File | canonical | base |
|---|---|---|
| `4.5/index.html` (versioned root) | `/documentation/index.html` injected | n/a |
| `4.5/apis/foo/bar.html` (versioned nested) | `/documentation/apis/foo/bar.html` injected | n/a |
| `4.5/already-canonical.html` (versioned, had canonical) | unchanged | n/a |
| `index.html` (mirror root) | `/documentation/index.html` (carried over) | `/documentation/4.5/` |
| `apis/foo/bar.html` (mirror nested) | `/documentation/apis/foo/bar.html` (carried over) | `/documentation/4.5/` |
| `already-canonical.html` (mirror, had canonical) | unchanged | `/documentation/4.5/` |

Script log: `Mirrored 4 HTML files, added canonical to 3 versioned files.`

## Test plan

- [ ] Dispatch the `Build Documentation` workflow on this branch (Actions tab).
- [ ] After it completes, spot-check `https://51degrees.github.io/documentation/4.5/_product_summaries__tested_versions.html` and a deep API page: `<link rel="canonical" href="/documentation/...">` present, root-relative, points at the unversioned form.
- [ ] Same spot-check on a mirror (`/documentation/_product_summaries__tested_versions.html`) confirms one canonical + one base, both unchanged from current behaviour.
- [ ] No file ends up with two canonical tags.
- [ ] `validate-html.ps1` passes.

## Related

- Resolves #159 (doxygen template should emit a single root-relative canonical per page).
- 51Degrees/Website#699 will drop the proxy-side canonical injection once this PR ships.