### PR TITLE
ci(build): serialise builds + retry gh-pages push on rejection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,15 @@ on:
   schedule:
     - cron:  '0 4 * * *'
 
+# Serialise builds: only one Build Documentation run touches gh-pages at a
+# time. Two parallel dispatches previously raced on `git push origin HEAD`
+# and the loser of the race exited non-zero. The deployed gh-pages was
+# still correct because the winning run had already pushed, but the
+# losing run reported a workflow failure that masked the real outcome.
+concurrency:
+  group: build-documentation-gh-pages
+  cancel-in-progress: false
+
 jobs:
   Build:
     runs-on: ubuntu-latest
@@ -27,8 +36,19 @@ jobs:
           if [[ -n $(git -C gh-pages status --porcelain | tee /dev/stderr) ]]; then echo changed=true >> "$GITHUB_OUTPUT"; fi
       - if: steps.changed.outputs.changed == 'true' && !inputs.dryrun
         working-directory: gh-pages
+        # Retry the push if gh-pages moved underneath us between the local
+        # commit and the push: pull --rebase, replay, push again. Backs up
+        # the concurrency guard above for the case where the gh-pages
+        # branch is updated by something other than this workflow.
         run: |
           git add .
           git -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' commit -m "Update documentation from $GITHUB_REF_NAME"
-          git push origin HEAD
-
+          for attempt in 1 2 3; do
+            if git push origin HEAD; then
+              exit 0
+            fi
+            echo "::warning::push attempt $attempt rejected; pulling --rebase and retrying"
+            git pull --rebase origin gh-pages
+          done
+          echo "::error::push to gh-pages failed after 3 attempts"
+          exit 1


### PR DESCRIPTION
## Summary

Two parallel manual dispatches of `Build Documentation` both built the same `main` commit `810a6fd4` in run-pair [#26998702926](https://github.com/51Degrees/documentation/actions/runs/26998702926) (failed at 06:13:37Z) and [#26998719411](https://github.com/51Degrees/documentation/actions/runs/26998719411) (succeeded at 06:13Z). Both finished the build successfully, then raced on `git push origin HEAD` to `gh-pages`. The losing run exited non-zero with:

\`\`\`
! [rejected]          HEAD -> gh-pages (fetch first)
error: failed to push some refs to 'https://github.com/51Degrees/documentation'
\`\`\`

The published `gh-pages` was correct because the winning run had already pushed, but the loser reported a workflow failure that masked the real outcome.

## Fix

Two layered guards:

1. **Workflow-level concurrency group** (`build-documentation-gh-pages`, `cancel-in-progress: false`) so only one `Build Documentation` run touches `gh-pages` at a time. Subsequent dispatches queue and run after the current one finishes.
2. **Retry-with-rebase on push** (up to 3 attempts) so a push rejection from any source (parallel build, hand commit, dependabot, etc.) recovers automatically. Surfaces a `::warning::` per retry and a final `::error::` only if all three attempts fail.

## Files
- `.github/workflows/build.yml`

## Test plan
- [ ] CI: the workflow file parses (GitHub Actions does this automatically on push).
- [ ] Trigger two dispatches in quick succession on this branch: only one should run at a time (the other queues).
- [ ] Verify gh-pages is updated once per merged dispatch, no spurious red runs.
- [ ] If a push really does fail three times in a row, the `::error::` line is visible in the run log.