### PR TITLE
fix(docs): correct two dead external links (Semrush #12)

### DIFF
--- a/src/devicedetection/quickstart.md
+++ b/src/devicedetection/quickstart.md
@@ -207,7 +207,7 @@ To get started with Go device detection On-premise:
 2. Ensure you have [Git LFS](https://git-lfs.github.com/) installed. The device data files are large binary files that can cause problems if stored in a Git repository directly, so Git LFS is used.
 3. Ensure all submodules are checked out by running `git submodule update --init --recursive` in the repository.
 4. Follow the [installation instructions](https://github.com/51Degrees/device-detection-go#build-and-usage) to get set up with the project.
-5. Follow the linked example here: [Getting Started](https://github.com/51Degrees/device-detection-examples-go/blob/main/dd/getting_started_test.go).
+5. Follow the linked example here: [Getting Started](https://github.com/51Degrees/device-detection-examples-go/blob/main/dd/getting_started/getting_started.go).
 6. (optional) Obtain a License Key by purchasing a subscription and download a data file with access to more devices and properties, see our [pricing page](https://51degrees.com/pricing) for details.
 
 @endsnippet

--- a/src/ipintelligence/features/human.md
+++ b/src/ipintelligence/features/human.md
@@ -10,4 +10,4 @@ We do this using a mixture of data points including the declarations made by the
 
 The `HumanProbability` property returns a value between `1` and `10`. The value is our assessment as to the likelihood that the provided IP address relates to a human, or not. `1` means it is very unlikely to be a human, `10` highly likely.
 
-See the [property dictionary](https://localhost:5002/developers/property-dictionary?item=Location%7CHuman%20Detection) for more information.
+See the [property dictionary](https://51degrees.com/developers/property-dictionary?item=Location%7CHuman%20Detection) for more information.


### PR DESCRIPTION
## Summary

Two dead external links in the docs source, surfaced by 51degrees.com Semrush audit issue #12.

- `src/ipintelligence/features/human.md` (line 13): the property dictionary link pointed at `https://localhost:5002/developers/property-dictionary?item=Location%7CHuman%20Detection`, a dev URL accidentally committed. Repointed at the production URL on 51degrees.com.

- `src/devicedetection/quickstart.md` (line 210): the Go quickstart link pointed at `dd/getting_started_test.go` in `device-detection-examples-go`, which 404s because that file was refactored into the directory `dd/getting_started/getting_started.go`. Repointed at the current path.

## Out of scope (false positives)

Five other Semrush #12 hits against this repo all live in `src/devicedetection/features/robotstxt.md` and use RFC 2606 / RFC 6761 reserved example domains to illustrate the TDL syntax:

- `https://example.com/robots.txt`
- `https://example.com/terms.txt`
- `https://a.example/terms`
- `https://b.example/terms`
- `https://custom.url/tdl`

These are intentionally non-resolvable and should be excluded in the Semrush audit settings on the 51degrees.com project rather than edited here.

## Test plan

- [ ] Render the docs site and confirm both links resolve to a 200 (property dictionary on 51degrees.com, getting_started.go on GitHub).
- [ ] After the next Semrush audit, confirm both URLs drop off issue #12.