### PR TITLE
fix(template): reduce CLS on every doxygen page (head stylesheets, image dimensions, reserved sidebar)

### DIFF
--- a/docs/HEADER-NOTES.md
+++ b/docs/HEADER-NOTES.md
@@ -45,6 +45,44 @@ substitutions:
 already interpolated into `<title>` below), so each page gets its own
 description rather than a project-wide blurb.
 
+## Why the stylesheets come before the scripts and the inline `<style>` block
+
+The doxygen template used to emit `tabs.css` first, then every script
+(`jquery.js`, `dynsections.js`, `examplegrabber.js`,
+`testedversionsgrabber.js`, `search51.js`, the `$treeview` expansion of
+`resize.js` + `navtreedata.js` + `navtree.js` + inline `initResizable`),
+and only then the main `$stylesheet` (`docs-main.css`). The render-
+blocking scripts in the middle delayed the docs stylesheet by a full
+network round trip, so the page painted with only `tabs.css` applied
+and re-flowed once `docs-main.css` arrived.
+
+Reordering so all stylesheets (`tabs.css`, `$stylesheet`,
+`$extrastylesheet`) precede the scripts lets the browser preload-scan
+and request the docs stylesheet in parallel with `tabs.css`, and the
+scripts then block on a stylesheet that is already in flight or done.
+
+The inline `<style>` block reserves two layout boxes ahead of asset
+arrival to keep Cumulative Layout Shift near zero:
+
+- `.c-brand__image { aspect-ratio: 360/67 }` matches the natural
+  dimensions of `/img/logo.png` (the file the website proxy swaps in
+  for `logo-51Degrees-Docs.png` on 51degrees.com). The `<img>` element
+  also gets matching `width="360" height="67"` attributes for browsers
+  that honour the attribute-derived aspect ratio rather than the CSS
+  one. Without the reservation the masthead first paints with a zero-
+  height image box and snaps down ~35 px when the bytes arrive.
+- `.c-sidenav { min-height: 600px }` at viewports below 993px keeps
+  the sidenav placeholder tall enough that `navtree.js` filling in the
+  tree does not push the main content downwards. Above 993px
+  `docs-main.css` already pins `.c-sidenav` to `position: fixed`, so
+  no reservation is needed there.
+
+Both rules are inlined into every page rather than added to
+`docs-main.css` so they take effect on first paint, before the
+external stylesheet finishes loading. The CSS is hand-minified to a
+single line to keep the per-page byte cost minimal (the rationale
+lives here, not in the template, per the next section).
+
 ## Why these notes are not inline comments
 
 A prior version had this rationale as `<!-- ... -->` blocks inside

--- a/docs/header.html
+++ b/docs/header.html
@@ -10,7 +10,11 @@
 <!--BEGIN !PROJECT_BRIEF--><!--BEGIN PROJECT_NAME--><meta name="description" content="$title - $projectname documentation."/><!--END PROJECT_NAME--><!--END !PROJECT_BRIEF-->
 <!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->
 <!--BEGIN !PROJECT_NAME--><title>$title</title><!--END !PROJECT_NAME-->
+<!-- Stylesheets ahead of scripts and inline CLS reservations; see HEADER-NOTES.md. -->
 <link href="$relpath^tabs.css" rel="stylesheet" type="text/css"/>
+<link href="$relpath^$stylesheet" rel="stylesheet" type="text/css" />
+$extrastylesheet
+<style type="text/css">.c-brand__image{aspect-ratio:360/67}@media (max-width:992px){.l-docs-index .g-docs__sidenav .c-sidenav{min-height:600px}}</style>
 <script type="text/javascript" src="$relpath^jquery.js"></script>
 <script type="text/javascript" src="$relpath^dynsections.js"></script>
 <script type="text/javascript" src="$relpath^examplegrabber.js"></script>
@@ -19,8 +23,6 @@
 $treeview
 $search
 $mathjax
-<link href="$relpath^$stylesheet" rel="stylesheet" type="text/css" />
-$extrastylesheet
 </head>
 <body class="l-docs-index p-doxygen">
 <div class="l-index__content">
@@ -30,7 +32,7 @@ $extrastylesheet
 <div id="titlearea" class="g-header g-header--docs">
   <div class="c-brand" role="banner">
   <!--BEGIN PROJECT_LOGO-->
-  <a id="projectlogo" href="$projecturl" class="c-brand__link"><img class="c-brand__image" alt="Logo" src="$relpath^$projectlogo" style="width:172px;"/></a>
+  <a id="projectlogo" href="$projecturl" class="c-brand__link"><img class="c-brand__image" alt="Logo" src="$relpath^$projectlogo" width="360" height="67" style="width:172px;height:auto;"/></a>
   <!--BEGIN PROJECT_NAME-->
   <span class="c-tagline">$projectname
    <!--BEGIN PROJECT_NUMBER-->&#160;<span id="projectnumber">$projectnumber</span><!--END PROJECT_NUMBER-->


### PR DESCRIPTION
## Summary

Three Cumulative Layout Shift sources removed from the shared doxygen header template, so every rendered `/documentation/*` page (and every API repo that uses this template as its `HTML_HEADER`) takes the win.

### 1. Docs stylesheet ahead of the render-blocking scripts

The template used to emit `tabs.css`, then every `<script>` (`jquery.js`, `dynsections.js`, `examplegrabber.js`, `testedversionsgrabber.js`, `search51.js`, the `$treeview` expansion of `resize.js` + `navtreedata.js` + `navtree.js` + inline `initResizable`), and only then `$stylesheet` (`docs-main.css`). The render-blocking scripts in the middle delayed the docs stylesheet by a full network round trip, so the page first painted with only `tabs.css` applied and re-flowed once `docs-main.css` arrived.

Reordering so all stylesheets (`tabs.css`, `$stylesheet`, `$extrastylesheet`) precede the scripts lets the browser preload-scan and request the docs stylesheet in parallel with `tabs.css`, and the scripts then block on a stylesheet that is already in flight or done.

### 2. Logo image with explicit dimensions

The `<img>` in the masthead used to ship with `style="width:172px;"` and no height, so the browser reserved width but not height. When the image bytes arrived, the masthead snapped down ~35 px.

Now the element carries `width="360" height="67"` attributes matching the natural dimensions of `/img/logo.png` (the file the website proxy swaps in for `logo-51Degrees-Docs.png` on 51degrees.com), plus an inline `aspect-ratio: 360/67` rule for browsers that only honour the CSS-derived aspect ratio. The inline `style="width:172px;height:auto;"` is kept so docs rendered outside the website (e.g. directly from GitHub Pages) still show the logo at the intended mobile size, with the height computed from the reserved aspect.

### 3. Reserved sidenav height on mobile and tablet

`navtree.js` builds the side navigation tree client-side. On viewports below 993px the `.c-sidenav` placeholder sits in normal flow above the main content, and the main content used to jump hundreds of pixels down as the tree filled in. An inline `min-height: 600px` reservation on `.c-sidenav` at `(max-width: 992px)` keeps the placeholder tall enough that the tree fits without pushing anything. Above 993px the existing `docs-main.css` already pins `.c-sidenav` to `position: fixed`, so no reservation is needed at desktop widths.

### Where the CSS lives

The new rules are inlined into every page via a hand-minified `<style>` block rather than added to `docs-main.css` so they take effect on first paint, before the external stylesheet finishes loading. Rationale lives in `docs/HEADER-NOTES.md` per the existing convention for non-obvious template shapes (HTML/CSS comments in the template would ship into roughly 5,500 generated pages per build).

## Files changed

- `docs/header.html`: stylesheet reorder, inline `<style>` block, logo width/height attributes.
- `docs/HEADER-NOTES.md`: rationale for the reorder and the inline reservations.

## Test plan

After the Build Documentation workflow runs and gh-pages updates:

- [ ] Load https://51degrees.com/documentation/_ip_intelligence__quickstart.html in Chrome with the Network and Performance panels recording. Expect CLS < 0.1.
- [ ] Spot-check three other doxygen pages: `/documentation/_pipeline_api__concepts__pipeline.html`, `/documentation/_device_detection__quickstart.html`, `/documentation/_ip_intelligence__index.html`. Expect CLS < 0.1 on each.
- [ ] Confirm the masthead logo paints at the same visual size as before on both mobile and desktop viewports (no distortion from the new width/height attributes).
- [ ] On a viewport below 993px, confirm the sidenav placeholder is tall enough that the main content does not visibly jump when `navtree.js` finishes building the tree.
- [ ] View page source on a rendered page and confirm `docs-main.min.css` now appears in `<head>` before any `<script>` tag, and that the inline `<style>` block is present.