### PR TITLE
fix(ci): add hreflang en-US alongside canonical in doxygen pages

### DIFF
--- a/ci/generate-documentation.ps1
+++ b/ci/generate-documentation.ps1
@@ -71,7 +71,9 @@ if (!(Test-Path "gh-pages/.nojekyll")) {
 # Each mirror gets <base href="/documentation/<version>/"> so relative
 # asset and nav refs still resolve into the versioned tree, and a
 # canonical link pointing back at the unversioned form so search
-# engines index that as the canonical URL.
+# engines index that as the canonical URL. The same loop emits an
+# hreflang="en-US" alternate alongside the canonical so the locale
+# signal matches the rest of 51degrees.com (single-locale site).
 #
 # A .mirror-manifest at the gh-pages root records what we wrote so the
 # next run (after a version bump or a Doxygen page rename) cleans up
@@ -87,6 +89,7 @@ $srcRoot = (Resolve-Path "gh-pages/$version").Path
 $baseTag = "<base href=`"/documentation/$version/`">"
 $mirrored = [System.Collections.Generic.List[string]]::new()
 $canonicalsAdded = 0
+$hreflangsAdded = 0
 Get-ChildItem -Recurse -File -Filter "*.html" -Path "gh-pages/$version" | ForEach-Object {
     $rel = $_.FullName.Substring($srcRoot.Length + 1) -replace '\\', '/'
     $dest = Join-Path "gh-pages" $rel
@@ -100,6 +103,13 @@ Get-ChildItem -Recurse -File -Filter "*.html" -Path "gh-pages/$version" | ForEac
     # staging, preview, localhost).
     $canonicalTag = "<link rel=`"canonical`" href=`"/documentation/$rel`">"
 
+    # hreflang alternate sharing the canonical's href so both
+    # declarations resolve to the same URL. en-US matches the rest of
+    # 51degrees.com (single-locale site); the website-side hreflang on
+    # every non-doxygen page also emits en-US, so /documentation/* now
+    # carries the same locale signal as the surrounding site.
+    $hreflangTag = "<link rel=`"alternate`" hreflang=`"en-US`" href=`"/documentation/$rel`" />"
+
     # Add canonical to the versioned source in place when it doesn't
     # already have one (doxygen-generated pages don't ship one). The
     # site's reverse proxy used to inject this at request time but
@@ -110,6 +120,16 @@ Get-ChildItem -Recurse -File -Filter "*.html" -Path "gh-pages/$version" | ForEac
         $content = $content -replace '(<head[^>]*>)', "`$1`n  $canonicalTag"
         Set-Content -Path $_.FullName -Value $content -NoNewline
         $canonicalsAdded++
+    }
+
+    # Inject the hreflang alternate immediately after the canonical so
+    # the two declarations stay adjacent and obviously paired. Skip if
+    # the page already carries an hreflang (idempotent on re-runs and
+    # safe against a future template change that ships one).
+    if ($content -notmatch '<link\s+rel=["'']?alternate["'']?\s+hreflang=') {
+        $content = $content -replace '(<link\s+rel="canonical"\s+href="[^"]*">)', "`$1`n  $hreflangTag"
+        Set-Content -Path $_.FullName -Value $content -NoNewline
+        $hreflangsAdded++
     }
 
     # Mirror copy under the unversioned root. The mirror adds <base>
@@ -124,7 +144,7 @@ Get-ChildItem -Recurse -File -Filter "*.html" -Path "gh-pages/$version" | ForEac
     $mirrored.Add($rel)
 }
 Set-Content -Path $manifestPath -Value ($mirrored -join "`n")
-Write-Host "Mirrored $($mirrored.Count) HTML files to gh-pages root, added canonical to $canonicalsAdded versioned files."
+Write-Host "Mirrored $($mirrored.Count) HTML files to gh-pages root, added canonical to $canonicalsAdded versioned files, added hreflang to $hreflangsAdded versioned files."
 Write-Host "::endgroup::"
 
 # Minify the Doxygen-emitted JS (jquery.js, navtree.js, dynsections.js,

--- a/docs/HEADER-NOTES.md
+++ b/docs/HEADER-NOTES.md
@@ -83,6 +83,20 @@ external stylesheet finishes loading. The CSS is hand-minified to a
 single line to keep the per-page byte cost minimal (the rationale
 lives here, not in the template, per the next section).
 
+## Why hreflang lives in the CI script, not the template
+
+The single hreflang declaration emitted on every doxygen page is
+`<link rel="alternate" hreflang="en-US" .../>`, matching the rest of
+51degrees.com (single-locale site; no x-default, no other locale).
+
+It is injected by `ci/generate-documentation.ps1` in the same mirror
+loop that injects the canonical, so both declarations share the same
+`/documentation/<rel>` href and stay adjacent in `<head>`. The
+template cannot construct that root-relative URL by itself (doxygen's
+`$relpath^` substitution is relative to the page being rendered, not
+to `/documentation/`), so doing it in the script is the only way to
+keep canonical and hreflang in agreement.
+
 ## Why these notes are not inline comments
 
 A prior version had this rationale as `<!-- ... -->` blocks inside


### PR DESCRIPTION
## Summary

Single-locale site, so every doxygen-served `/documentation/*` page now declares `hreflang="en-US"` alongside the existing canonical, matching the hreflang the rest of 51degrees.com now emits. No `x-default`, no other locale.

The injection lives in `ci/generate-documentation.ps1`, in the same mirror loop that injects the canonical (PR #160). The hreflang's `href` shares the canonical's `/documentation/<rel>` root-relative URL verbatim so both declarations resolve to the same place, and it sits adjacent to the canonical in `<head>` so the pair is obvious.

### Why not `docs/header.html`?

The canonical that this hreflang must match (for both href shape and emission scope) is itself injected by the CI script, not the doxygen template. The template's `$relpath^` substitution is page-relative, not site-rooted, so a root-relative `/documentation/<rel>` href cannot be constructed there. Keeping both declarations in the same loop is the only way to guarantee they stay in lockstep.

`docs/HEADER-NOTES.md` gains a short note pointing future readers at the CI script.

## Test plan

- [ ] After this PR merges and the `Build Documentation` workflow runs against `main`, fetch a versioned page and confirm both declarations are present and agree:
      `curl -s https://51degrees.github.io/documentation/4.5/_device_detection__quickstart.html | grep -E 'rel="(canonical|alternate)"'`
      expected:
      ```
      <link rel="canonical" href="/documentation/_device_detection__quickstart.html">
      <link rel="alternate" hreflang="en-US" href="/documentation/_device_detection__quickstart.html" />
      ```
- [ ] Same check on the unversioned mirror (`/documentation/_device_detection__quickstart.html`).
- [ ] Confirm no page ends up with two hreflang tags (the injection is gated on an existing-hreflang regex, idempotent on re-runs).
- [ ] `validate-html.ps1` continues to pass (only checks `<img>` alt attributes; hreflang is out of scope).