### PR TITLE
fix(template): demote body-level H1 tags to H2 in post-processed gh-pages

### DIFF
--- a/ci/rebalance-doc-headings.ps1
+++ b/ci/rebalance-doc-headings.ps1
@@ -14,14 +14,27 @@
     every one of them under /documentation/4.5/. See documentation
     issue #154 for the full investigation.
 
-    This script promotes the page-title h2 to h1 and demotes each
-    section-heading h1 to h2 by class. Class attributes (and any
-    other attributes on the tag) are preserved so existing CSS and
-    fragment links continue to work.
+    Three passes run in order:
+
+    1. Promote the page-title h2 to h1 by class
+       (`g-docs__page-title`).
+    2. Demote each section-heading h1 to h2 by class
+       (`g-docs__section-heading`).
+    3. Demote every remaining body-level h1 to h2 (Doxygen also
+       converts plain markdown `# Section Title` lines to <h1>
+       with no recognisable class, e.g.
+       `<h1><a class="anchor" id="..."></a> Title</h1>`).
+       The page-title h1 produced by pass 1 is preserved because
+       it carries `class="g-docs__page-title"`.
+
+    Class attributes (and any other attributes on the tag) are
+    preserved on every rewrite so existing CSS and fragment links
+    continue to work.
 
     The transform is idempotent: re-running on already-rebalanced
     HTML is a no-op because the class selectors no longer match
-    the original tag names.
+    the original tag names and the only remaining <h1> is the
+    page-title h1, which pass 3 skips.
 
 .PARAMETER Path
     Directory to walk recursively for *.html files. Mandatory.
@@ -59,11 +72,20 @@ if (-not (Test-Path $Path)) {
     throw "Path '$Path' does not exist."
 }
 
+# Catch-all opening-tag pattern for pass 3. Matches any <h1 ...>
+# regardless of attributes (or lack of). The body-h1 sweep below
+# inspects each match's attributes and skips the page-title h1
+# produced by pass 1.
+$bodyH1OpenPattern = '(?i)<h1(\b[^>]*)>'
+$pageTitleClassPattern = `
+    '(?i)class\s*=\s*(["''])[^"'']*\bg-docs__page-title\b[^"'']*\1'
+
 $resolved = (Resolve-Path $Path).Path
 $totalFiles = 0
 $changedFiles = 0
 $totalPageTitlePromotions = 0
 $totalSectionHeadingDemotions = 0
+$totalBodyH1Demotions = 0
 
 foreach ($file in Get-ChildItem -Path $resolved -Recurse -File -Filter '*.html') {
     $totalFiles++
@@ -74,20 +96,44 @@ foreach ($file in Get-ChildItem -Path $resolved -Recurse -File -Filter '*.html')
     # tags we rewrote in each file.
     $promotions = [regex]::Matches($original, $pageTitlePattern).Count
     $demotions = [regex]::Matches($original, $sectionHeadingPattern).Count
-    if ($promotions -eq 0 -and $demotions -eq 0) {
-        continue
-    }
 
     $rewritten = $original -replace `
         $pageTitlePattern, $pageTitleReplacement
     $rewritten = $rewritten -replace `
         $sectionHeadingPattern, $sectionHeadingReplacement
 
+    # Pass 3: demote any remaining body <h1> that is NOT the
+    # page-title h1 (which now carries `class="g-docs__page-title"`
+    # after pass 1). Doxygen converts plain markdown `# Title`
+    # lines to <h1> with no recognisable class, so the by-class
+    # passes above miss them. Walk the matches in reverse so
+    # earlier rewrites do not shift later indices, and rewrite
+    # the closing </h1> before the opening <h1 so the opening
+    # tag's stored Index stays valid.
+    $bodyMatches = [regex]::Matches($rewritten, $bodyH1OpenPattern)
+    $bodyDemotions = 0
+    for ($i = $bodyMatches.Count - 1; $i -ge 0; $i--) {
+        $m = $bodyMatches[$i]
+        $attrs = $m.Groups[1].Value
+        if ($attrs -match $pageTitleClassPattern) { continue }
+        $closeAt = $rewritten.IndexOf(
+            '</h1>', $m.Index + $m.Length,
+            [System.StringComparison]::OrdinalIgnoreCase)
+        if ($closeAt -lt 0) { continue }
+        # Replace closing tag first so the opening-tag index stays
+        # valid for the second Remove/Insert.
+        $rewritten = $rewritten.Remove($closeAt, 5).Insert($closeAt, '</h2>')
+        $rewritten = $rewritten.Remove($m.Index, $m.Length).Insert(
+            $m.Index, '<h2' + $attrs + '>')
+        $bodyDemotions++
+    }
+
     if ($rewritten -ne $original) {
         Set-Content -Path $file.FullName -Value $rewritten -NoNewline
         $changedFiles++
         $totalPageTitlePromotions += $promotions
         $totalSectionHeadingDemotions += $demotions
+        $totalBodyH1Demotions += $bodyDemotions
     }
 }
 
@@ -95,5 +141,6 @@ Write-Host (
     "rebalance-doc-headings: scanned $totalFiles files, " +
     "rewrote $changedFiles, " +
     "promoted $totalPageTitlePromotions page-title h2 -> h1, " +
-    "demoted $totalSectionHeadingDemotions section-heading h1 -> h2."
+    "demoted $totalSectionHeadingDemotions section-heading h1 -> h2, " +
+    "demoted $totalBodyH1Demotions body-level h1 -> h2."
 )

--- a/docs/HEADER-NOTES.md
+++ b/docs/HEADER-NOTES.md
@@ -97,6 +97,29 @@ template cannot construct that root-relative URL by itself (doxygen's
 to `/documentation/`), so doing it in the script is the only way to
 keep canonical and hreflang in agreement.
 
+## Why heading rebalancing lives in a CI script, not the template
+
+Doxygen ships the page title at `<h2 class="g-docs__page-title">`
+and every section heading at `<h1 class="g-docs__section-heading">`,
+and also converts top-level markdown `# Section Title` lines to
+plain `<h1>` with no recognisable class. Each rendered page therefore
+carries N+1 `<h1>` tags and no `<h1>` for the actual page title,
+which Semrush rule 104 ("Multiple H1 tags") flags.
+
+`ci/rebalance-doc-headings.ps1` runs over the gh-pages tree after
+the mirror loop and rewrites three things by regex:
+
+1. Promote the page-title `<h2>` to `<h1>` by class.
+2. Demote every section-heading `<h1>` to `<h2>` by class.
+3. Demote any remaining body-level `<h1>` to `<h2>` (the
+   class-less ones doxygen emits for markdown section titles).
+   The page-title `<h1>` from pass 1 is preserved because it
+   carries `class="g-docs__page-title"`.
+
+Doing this in CI rather than patching the template lets the same
+rule apply uniformly across every API repo's doxygen output without
+needing each one to re-pull a template change.
+
 ## Why these notes are not inline comments
 
 A prior version had this rationale as `<!-- ... -->` blocks inside


### PR DESCRIPTION
## Summary

Closes the residual Semrush rule 104 (\"Multiple H1 tags\") notice that survived PR #155. The latest crawl flagged 34 pages with more than one `<h1>` under `/documentation/4.5/`.

PR #155's `rebalance-doc-headings.ps1` rewrites doxygen's heading hierarchy by class:

1. Promote the page-title `<h2 class=\"g-docs__page-title\">` to `<h1>`.
2. Demote each `<h1 class=\"g-docs__section-heading\">` to `<h2>`.

Two gaps remained, both surfaced as multi-H1 pages by the recent Semrush crawl:

- Doxygen converts top-level markdown `# Section Title` lines to plain `<h1>` with no recognisable class, so the by-class demotion misses them. Example: `_device_detection__features__performance_options.html` had `<h1><a class=\"anchor\" id=\"faster-property-retrieval\"></a> Property Indexing</h1>` (line 97) sitting alongside the page-title H1.
- The existing section-heading demotion pattern requires `[^<]*` inner text, so it skips any section-heading H1 whose label contains inline tags (anchors, links). Example: `_device_detection__upgradingto_v4.html` had `<h1 class=\"g-docs__section-heading\">Migration Guides <a href=\"#migration-guides\">#</a><a class=\"anchor\" id=\"migration-guides\"></a></h1>` (line 99) untouched.

This PR adds a third pass to `rebalance-doc-headings.ps1`:

- For every remaining `<h1 ...>` opening tag in the body, inspect its attributes. If `class=\".*g-docs__page-title.*\"` is present, leave it alone (it is the page title produced by pass 1). Otherwise rewrite the opening tag to `<h2 ...>` (attributes preserved) and the matching `</h1>` to `</h2>`.
- The sweep walks matches in reverse and rewrites the closing tag before the opening tag, so earlier rewrites do not invalidate later indices.
- Idempotent on re-run: the only remaining `<h1>` after a pass is the page-title one, which the attribute check skips.

The third pass runs in the same script as the existing two, so the whole heading-rebalancing rule lives in one file. `docs/HEADER-NOTES.md` gains a short note pointing future readers at the CI script (alongside the existing canonical/hreflang note).

## Test plan

- [ ] After this PR merges and the `Build Documentation` workflow runs against `main`, fetch a previously-multi-H1 page and confirm the count drops to 1:
      `curl -s https://51degrees.github.io/documentation/4.5/_device_detection__features__performance_options.html | grep -c '<h1'`
      expected: `1`
- [ ] Same check on `_device_detection__upgradingto_v4.html`.
- [ ] Spot-check that the remaining `<h1>` on each rewritten page is the page-title H1 (`<h1 class=\"g-docs__page-title\">...`).
- [ ] CI's `rebalance-doc-headings` log line reports a non-zero `demoted N body-level h1 -> h2` count for the build that processes the affected pages.
- [ ] Re-running CI on already-rebalanced HTML is a no-op (idempotency).