### PR TITLE
fix(ci): emit hreflang only on self-canonical mirror pages

### DIFF
--- a/ci/generate-documentation.ps1
+++ b/ci/generate-documentation.ps1
@@ -71,9 +71,15 @@ if (!(Test-Path "gh-pages/.nojekyll")) {
 # Each mirror gets <base href="/documentation/<version>/"> so relative
 # asset and nav refs still resolve into the versioned tree, and a
 # canonical link pointing back at the unversioned form so search
-# engines index that as the canonical URL. The same loop emits an
-# hreflang="en-US" alternate alongside the canonical so the locale
-# signal matches the rest of 51degrees.com (single-locale site).
+# engines index that as the canonical URL.
+#
+# The hreflang="en-US" alternate is emitted only on the unversioned
+# mirror, never on the versioned source. The versioned URL canonicals
+# at a different URL (the unversioned one), so emitting a hreflang
+# anchor at that different URL from the versioned page is the cross-
+# URL mismatch Semrush flags as a hreflang conflict (rule 24) or an
+# incorrect hreflang link (rule 25). The mirror is self-canonical, so
+# it carries the locale signal cleanly.
 #
 # A .mirror-manifest at the gh-pages root records what we wrote so the
 # next run (after a version bump or a Doxygen page rename) cleans up
@@ -114,32 +120,46 @@ Get-ChildItem -Recurse -File -Filter "*.html" -Path "gh-pages/$version" | ForEac
     # already have one (doxygen-generated pages don't ship one). The
     # site's reverse proxy used to inject this at request time but
     # pinned the rendered HTML to one host; doing it here once at
-    # build time keeps the output portable. See
-    # 51Degrees/Website#699 for the corresponding proxy-side change.
+    # build time keeps the output portable.
     if ($content -notmatch '<link\s+rel=["'']?canonical') {
         $content = $content -replace '(<head[^>]*>)', "`$1`n  $canonicalTag"
         Set-Content -Path $_.FullName -Value $content -NoNewline
         $canonicalsAdded++
     }
 
-    # Inject the hreflang alternate immediately after the canonical so
-    # the two declarations stay adjacent and obviously paired. Skip if
-    # the page already carries an hreflang (idempotent on re-runs and
-    # safe against a future template change that ships one).
-    if ($content -notmatch '<link\s+rel=["'']?alternate["'']?\s+hreflang=') {
-        $content = $content -replace '(<link\s+rel="canonical"\s+href="[^"]*">)', "`$1`n  $hreflangTag"
-        Set-Content -Path $_.FullName -Value $content -NoNewline
-        $hreflangsAdded++
-    }
-
     # Mirror copy under the unversioned root. The mirror adds <base>
-    # so relative refs into versioned assets still resolve, and we
-    # ensure the canonical is present (carried over from the in-place
-    # update above, or copied in here for the rare file that already
-    # had a self-canonical).
+    # so relative refs into versioned assets still resolve, and the
+    # canonical is carried over from the in-place update above (or
+    # from the doxygen template for the rare file that already had
+    # a self-canonical).
     if ($content -notmatch '<base\s') {
         $content = $content -replace '(<head[^>]*>)', "`$1`n  $baseTag"
     }
+
+    # Inject the hreflang alternate into the mirror only, and only when
+    # the existing canonical on this page points at the mirror's own
+    # URL. Two conditions have to hold:
+    #   * The page does not already carry an hreflang (idempotent on
+    #     re-runs and safe against a future template change that ships
+    #     one).
+    #   * The canonical href equals /documentation/$rel (i.e. the
+    #     mirror's URL). Pages whose canonical points elsewhere -- e.g.
+    #     api-repo doxygen pages whose own template sets a different
+    #     consolidation target -- are not self-canonical and so must
+    #     not declare a hreflang anchor at a URL different from their
+    #     own.
+    $mirrorUrl = "/documentation/$rel"
+    $existingCanonical = $null
+    $canonicalMatch = [regex]::Match($content, '<link\s+rel="canonical"\s+href="([^"]+)"')
+    if ($canonicalMatch.Success) {
+        $existingCanonical = $canonicalMatch.Groups[1].Value
+    }
+    if ($existingCanonical -eq $mirrorUrl -and
+        $content -notmatch '<link\s+rel=["'']?alternate["'']?\s+hreflang=') {
+        $content = $content -replace '(<link\s+rel="canonical"\s+href="[^"]*">)', "`$1`n  $hreflangTag"
+        $hreflangsAdded++
+    }
+
     Set-Content -Path $dest -Value $content -NoNewline
     $mirrored.Add($rel)
 }

--- a/docs/HEADER-NOTES.md
+++ b/docs/HEADER-NOTES.md
@@ -85,17 +85,26 @@ lives here, not in the template, per the next section).
 
 ## Why hreflang lives in the CI script, not the template
 
-The single hreflang declaration emitted on every doxygen page is
+The single hreflang declaration emitted on doxygen pages is
 `<link rel="alternate" hreflang="en-US" .../>`, matching the rest of
 51degrees.com (single-locale site; no x-default, no other locale).
 
-It is injected by `ci/generate-documentation.ps1` in the same mirror
-loop that injects the canonical, so both declarations share the same
-`/documentation/<rel>` href and stay adjacent in `<head>`. The
-template cannot construct that root-relative URL by itself (doxygen's
-`$relpath^` substitution is relative to the page being rendered, not
-to `/documentation/`), so doing it in the script is the only way to
-keep canonical and hreflang in agreement.
+It is injected by `ci/generate-documentation.ps1` after the canonical
+so both declarations share the same `/documentation/<rel>` href and
+stay adjacent in `<head>`. The template cannot construct that root-
+relative URL by itself (doxygen's `$relpath^` substitution is relative
+to the page being rendered, not to `/documentation/`), so doing it in
+the script is the only way to keep canonical and hreflang in agreement.
+
+The hreflang is emitted only on the unversioned mirror, never on the
+versioned source: the versioned source canonicals at a different URL
+(the unversioned one), so emitting a hreflang anchor at that different
+URL from the versioned page is the cross-URL mismatch Semrush flags as
+a hreflang conflict (rule 24) or an incorrect hreflang link (rule 25).
+The mirror is self-canonical, so it carries the locale signal cleanly.
+The mirror loop also gates the injection on the existing canonical href
+matching the mirror's own URL, so api-repo pages whose template sets a
+different consolidation target stay unmodified.
 
 ## Why these notes are not inline comments
 


### PR DESCRIPTION
## Why this PR exists

The post-deploy Semrush audit on 51degrees.com (run 2026-06-06 09:21Z) shows the hreflang en-US declaration shipped in #165 traded one hreflang error class for another:

| Rule | Pre-deploy | Post-deploy | Delta |
|---|---|---|---|
| #24 Hreflang conflicts in page source | 1,396 | 1,392 | -4 |
| #25 Incorrect hreflang links (NEW) | 0 | **350** | **+350** |
| **Total errors** | 1,483 | 1,836 | **+353** |
| **Site Health** | 82 | 79 | **-3** |

## Root cause

The mirror loop in `ci/generate-documentation.ps1` injected both canonical and hreflang into the versioned source in place, then copied that content to the unversioned mirror. So:

* **Versioned page** `/documentation/4.5/foo.html` carried:
  * canonical → `/documentation/foo.html` (correct: consolidates equity at the unversioned URL)
  * hreflang en-US → `/documentation/foo.html` (**wrong**: declares a locale anchor at a URL different from the page's own URL)
* **Unversioned mirror** `/documentation/foo.html` carried both pointing at itself (correct).

Every versioned doxygen page had the same cross-URL mismatch the website's parameterised URLs had on the Razor side: page URL ≠ hreflang href → Semrush rule #24 or #25.

## Fix

Inject hreflang only on the unversioned mirror, and only when the existing canonical href matches the mirror's own URL.

* The versioned source keeps its canonical (no change).
* The mirror keeps its `<base>`, canonical (carried over), and now its hreflang.
* The gate (`existing canonical == mirror URL`) means api-repo doxygen pages whose own template sets a different consolidation target are left unmodified.

```powershell
$mirrorUrl = "/documentation/$rel"
$canonicalMatch = [regex]::Match($content, '<link\s+rel="canonical"\s+href="([^"]+)"')
if ($canonicalMatch.Success -and
    $canonicalMatch.Groups[1].Value -eq $mirrorUrl -and
    $content -notmatch '<link\s+rel=["'']?alternate["'']?\s+hreflang=') {
    $content = $content -replace '(<link\s+rel="canonical"\s+href="[^"]*">)', "`$1`n  $hreflangTag"
    $hreflangsAdded++
}
```

`docs/HEADER-NOTES.md` has its hreflang-rationale section updated to document the gate.

## Expected impact on next audit

| Rule | Now | After this PR + Website PR #734 |
|---|---|---|
| #24 Hreflang conflicts | 1,392 | ~0 |
| #25 Incorrect hreflang links | 350 | ~0 |

## Stacks with

* **51Degrees/Website PR #734** — same self-canonical gate, applied to the layout-side hreflang emit on parameterised URLs and ViewData-overridden canonical pages.
* **51Degrees/Website PR #733** — keeps the proxy's absolute-URL rewrite as a safety net for any docs page whose hreflang slips through as root-relative.

## Test plan

- [ ] CI passes (build, validate-html)
- [ ] After this lands and `Build Documentation` propagates: `curl -sS https://51degrees.com/documentation/4.5/_device_detection__quickstart.html | grep hreflang` returns nothing
- [ ] Same path under the mirror: `curl -sS https://51degrees.com/documentation/_device_detection__quickstart.html | grep hreflang` returns the en-US declaration with the mirror's own URL
- [ ] Next Semrush full audit shows #24 and #25 both ≈ 0