### PR TITLE
fix(content): expand thin Getting Started landing pages (Semrush 117/102/113)

### DIFF
--- a/src/devicedetection/examples/gettingstartedconsole/index.md
+++ b/src/devicedetection/examples/gettingstartedconsole/index.md
@@ -21,8 +21,8 @@ Two deployment models are covered:
   when you need the lowest per-call latency. See
   @ref DeviceDetection_Examples_GettingStarted_Console_OnPremise.
 
-Both examples are available in C#, Java, Node.js, PHP and Python with matching
-pattern, so you can compare the same logic across languages. If you intend to
+Both examples are available across every supported language with a matching
+pattern, so the same logic can be compared side by side. If you intend to
 deploy inside a web framework rather than a console, see
 @ref DeviceDetection_Examples_GettingStarted_Web_Index instead.
 

--- a/src/devicedetection/examples/gettingstartedconsole/index.md
+++ b/src/devicedetection/examples/gettingstartedconsole/index.md
@@ -1,5 +1,31 @@
 @page DeviceDetection_Examples_GettingStarted_Console_Index Getting Started - Console
 
+# Introduction
+
+The Getting Started Console examples show how to call 51Degrees @devicedetection
+from a standalone command-line program. They are the shortest possible end-to-end
+walkthrough: build a pipeline, hand it a User-Agent (and optionally a set of
+[User-Agent Client Hints](@ref DeviceDetection_Features_UACH_Overview)), and print
+the resulting properties. Use them as the starting point for batch processing,
+ad-hoc lookups, automation scripts, or as a sanity check before wiring the
+pipeline into a larger application.
+
+Two deployment models are covered:
+
+- **Cloud** — calls 51Degrees' hosted Cloud service over HTTPS. The simplest
+  path to a working detection: a Resource Key configures the pipeline, no data
+  file is needed locally. See @ref DeviceDetection_Examples_GettingStarted_Console_Cloud.
+
+- **On-premise** — runs the Hash engine inside your own process against a
+  locally distributed data file. Suitable when network access is restricted or
+  when you need the lowest per-call latency. See
+  @ref DeviceDetection_Examples_GettingStarted_Console_OnPremise.
+
+Both examples are available in C#, Java, Node.js, PHP and Python with matching
+shape, so you can compare the same logic across languages. If you intend to
+deploy inside a web framework rather than a console, see
+@ref DeviceDetection_Examples_GettingStarted_Web_Index instead.
+
 @subpage DeviceDetection_Examples_GettingStarted_Console_Cloud
 
 @subpage DeviceDetection_Examples_GettingStarted_Console_OnPremise

--- a/src/devicedetection/examples/gettingstartedconsole/index.md
+++ b/src/devicedetection/examples/gettingstartedconsole/index.md
@@ -22,7 +22,7 @@ Two deployment models are covered:
   @ref DeviceDetection_Examples_GettingStarted_Console_OnPremise.
 
 Both examples are available in C#, Java, Node.js, PHP and Python with matching
-shape, so you can compare the same logic across languages. If you intend to
+pattern, so you can compare the same logic across languages. If you intend to
 deploy inside a web framework rather than a console, see
 @ref DeviceDetection_Examples_GettingStarted_Web_Index instead.
 

--- a/src/devicedetection/examples/gettingstartedweb/index.md
+++ b/src/devicedetection/examples/gettingstartedweb/index.md
@@ -1,5 +1,32 @@
 @page DeviceDetection_Examples_GettingStarted_Web_Index Getting Started - Web
 
+# Introduction
+
+The Getting Started Web examples show how to add 51Degrees @devicedetection to a
+web application. The pipeline runs on each incoming HTTP request, reads the
+User-Agent and any [User-Agent Client Hints](@ref DeviceDetection_Features_UACH_Overview)
+the browser sent, and exposes the detected device, operating system and browser
+properties to your handler so you can adapt the response.
+
+Two deployment models are covered:
+
+- **Cloud** — calls 51Degrees' hosted Cloud service over HTTPS. No data file
+  to manage, no on-premise binary to update; suitable for traffic that already
+  reaches a public endpoint and for teams who want the fastest path to a
+  working integration. See @ref DeviceDetection_Examples_GettingStarted_Web_Cloud.
+
+- **On-premise** — runs the Hash engine inside your own process against a
+  locally distributed data file. Suitable for workloads that need offline
+  operation, predictable latency, or the highest request throughput. See
+  @ref DeviceDetection_Examples_GettingStarted_Web_OnPremise.
+
+Both examples follow the same shape: configure a pipeline, register it with
+the framework, and read the detected properties off the request. Each ships
+side-by-side snippets for ASP.NET Core, ASP.NET Framework, Java, Node.js, PHP
+and Python, so you can pick the language that matches your stack and skip the
+rest. If you are evaluating which deployment model fits your use case first,
+see @ref DeviceDetection_CloudToOnPremise for a comparison.
+
 @subpage DeviceDetection_Examples_GettingStarted_Web_Cloud
 
 @subpage DeviceDetection_Examples_GettingStarted_Web_OnPremise

--- a/src/devicedetection/examples/gettingstartedweb/index.md
+++ b/src/devicedetection/examples/gettingstartedweb/index.md
@@ -20,7 +20,7 @@ Two deployment models are covered:
   operation, predictable latency, or the highest request throughput. See
   @ref DeviceDetection_Examples_GettingStarted_Web_OnPremise.
 
-Both examples follow the same shape: configure a pipeline, register it with
+Both examples follow the same pattern: configure a pipeline, register it with
 the framework, and read the detected properties off the request. Each ships
 side-by-side snippets for ASP.NET Core, ASP.NET Framework, Java, Node.js, PHP
 and Python, so you can pick the language that matches your stack and skip the

--- a/src/devicedetection/examples/gettingstartedweb/index.md
+++ b/src/devicedetection/examples/gettingstartedweb/index.md
@@ -22,10 +22,10 @@ Two deployment models are covered:
 
 Both examples follow the same pattern: configure a pipeline, register it with
 the framework, and read the detected properties off the request. Each ships
-side-by-side snippets for ASP.NET Core, ASP.NET Framework, Java, Node.js, PHP
-and Python, so you can pick the language that matches your stack and skip the
-rest. If you are evaluating which deployment model fits your use case first,
-see @ref DeviceDetection_CloudToOnPremise for a comparison.
+side-by-side snippets across every supported language and web framework, so
+you can pick the one that matches your stack and skip the rest. If you are
+evaluating which deployment model fits your use case first, see
+@ref DeviceDetection_CloudToOnPremise for a comparison.
 
 @subpage DeviceDetection_Examples_GettingStarted_Web_Cloud
 

--- a/src/devicedetection/examples/performance/index.md
+++ b/src/devicedetection/examples/performance/index.md
@@ -18,7 +18,7 @@ trade memory for throughput on your target hosts. The example covers the
 On-premise Hash engine — Cloud performance is dominated by network round-trip
 and is not benchmarked here.
 
-The example ships for C, C# (.NET), Java, Node.js, and Python with matching
-pattern, so the same workload can be measured across runtimes.
+The example ships across every supported language with a matching pattern, so
+the same workload can be measured across runtimes.
 
 @subpage DeviceDetection_Examples_Performance_OnPremiseHash

--- a/src/devicedetection/examples/performance/index.md
+++ b/src/devicedetection/examples/performance/index.md
@@ -1,3 +1,24 @@
 @page DeviceDetection_Examples_Performance_Index Performance
 
+# Introduction
+
+The Performance examples measure how fast the 51Degrees @devicedetection engine
+processes evidence (User-Agents and [User-Agent Client Hints](@ref DeviceDetection_Features_UACH_Overview))
+on your own hardware. They run a tight loop over a fixed set of User-Agent
+strings, count detections per second, and report mean and p99 latencies, so you
+can size capacity, validate tuning changes, and compare deployment models on
+the platform you actually run.
+
+The companion @ref DeviceDetection_Features_PerformanceOptions page describes
+the configuration knobs that drive throughput and memory: the
+**Performance Profile** (`LowMemory`, `Balanced`, `HighPerformance`, `MaxPerformance`),
+how the data file is loaded, and the size of the property and value caches.
+Pick a profile, run the example, and use the numbers to decide whether to
+trade memory for throughput on your target hosts. The example covers the
+On-premise Hash engine — Cloud performance is dominated by network round-trip
+and is not benchmarked here.
+
+The example ships for C, C# (.NET), Java, Node.js, and Python with matching
+shape, so the same workload can be measured across runtimes.
+
 @subpage DeviceDetection_Examples_Performance_OnPremiseHash

--- a/src/devicedetection/examples/performance/index.md
+++ b/src/devicedetection/examples/performance/index.md
@@ -19,6 +19,6 @@ On-premise Hash engine — Cloud performance is dominated by network round-trip
 and is not benchmarked here.
 
 The example ships for C, C# (.NET), Java, Node.js, and Python with matching
-shape, so the same workload can be measured across runtimes.
+pattern, so the same workload can be measured across runtimes.
 
 @subpage DeviceDetection_Examples_Performance_OnPremiseHash

--- a/src/ipintelligence/examples/gettingstartedconsole/index.md
+++ b/src/ipintelligence/examples/gettingstartedconsole/index.md
@@ -23,7 +23,7 @@ Two deployment models are covered:
   @ref IpIntelligence_Examples_GettingStarted_Console_OnPremise.
 
 Both examples are available in C#, Java, Node.js, PHP and Python with matching
-shape, so the same logic can be compared across languages. If you intend to
+pattern, so the same logic can be compared across languages. If you intend to
 deploy inside a web framework rather than a console, see
 @ref IpIntelligence_Examples_GettingStarted_Web_Index instead.
 

--- a/src/ipintelligence/examples/gettingstartedconsole/index.md
+++ b/src/ipintelligence/examples/gettingstartedconsole/index.md
@@ -1,4 +1,31 @@
-@page IpIntelligence_Examples_GettingStarted_Console_Index Getting Started - Console
+@page IpIntelligence_Examples_GettingStarted_Console_Index Getting Started - Console (IP Intelligence)
+
+# Introduction
+
+The Getting Started Console examples show how to call 51Degrees IP Intelligence
+from a standalone command-line program. They are the shortest end-to-end
+walkthrough for the engine: build a pipeline, hand it an IP address, and print
+the resulting properties such as country, region, city, ASN, registered name,
+estimated bandwidth and connection type. Use them as the starting point for
+batch enrichment, ad-hoc lookups, automation scripts, or as a sanity check
+before wiring the pipeline into a larger application.
+
+Two deployment models are covered:
+
+- **Cloud** — calls 51Degrees' hosted Cloud service over HTTPS. A Resource Key
+  configures the pipeline; no data file is needed locally. Best for the fastest
+  path to a working integration. See
+  @ref IpIntelligence_Examples_GettingStarted_Console_Cloud.
+
+- **On-premise** — runs the IP Intelligence engine inside your own process
+  against a locally distributed data file. Best when network access is
+  restricted or when you need the lowest per-call latency. See
+  @ref IpIntelligence_Examples_GettingStarted_Console_OnPremise.
+
+Both examples are available in C#, Java, Node.js, PHP and Python with matching
+shape, so the same logic can be compared across languages. If you intend to
+deploy inside a web framework rather than a console, see
+@ref IpIntelligence_Examples_GettingStarted_Web_Index instead.
 
 @subpage IpIntelligence_Examples_GettingStarted_Console_Cloud
 

--- a/src/ipintelligence/examples/gettingstartedconsole/index.md
+++ b/src/ipintelligence/examples/gettingstartedconsole/index.md
@@ -22,8 +22,8 @@ Two deployment models are covered:
   restricted or when you need the lowest per-call latency. See
   @ref IpIntelligence_Examples_GettingStarted_Console_OnPremise.
 
-Both examples are available in C#, Java, Node.js, PHP and Python with matching
-pattern, so the same logic can be compared across languages. If you intend to
+Both examples are available across every supported language with a matching
+pattern, so the same logic can be compared side by side. If you intend to
 deploy inside a web framework rather than a console, see
 @ref IpIntelligence_Examples_GettingStarted_Web_Index instead.
 

--- a/src/ipintelligence/examples/gettingstartedweb/index.md
+++ b/src/ipintelligence/examples/gettingstartedweb/index.md
@@ -23,8 +23,8 @@ Two deployment models are covered:
 
 Both examples follow the same pattern: configure a pipeline, register it with
 the framework, hand it the request and read the detected properties off the
-result. Snippets are shown side by side for ASP.NET Core, Java, Node.js, PHP
-and Python so you can pick the language that matches your stack. For console
+result. Snippets are shown side by side across every supported language and
+web framework, so you can pick the one that matches your stack. For console
 or batch-style integrations, see @ref IpIntelligence_Examples_GettingStarted_Console_Index
 instead.
 

--- a/src/ipintelligence/examples/gettingstartedweb/index.md
+++ b/src/ipintelligence/examples/gettingstartedweb/index.md
@@ -1,4 +1,32 @@
-@page IpIntelligence_Examples_GettingStarted_Web_Index Getting Started - Web
+@page IpIntelligence_Examples_GettingStarted_Web_Index Getting Started - Web (IP Intelligence)
+
+# Introduction
+
+The Getting Started Web examples show how to add 51Degrees IP Intelligence to
+a web application. The pipeline runs on each incoming HTTP request, reads the
+client IP from the headers, and exposes geolocation, network classification
+and connection-type properties (country, region, city, ASN, registered name,
+estimated bandwidth, mobile carrier, and more) to your handler so you can
+personalise the response, enforce regional rules, or route traffic.
+
+Two deployment models are covered:
+
+- **Cloud** — calls 51Degrees' hosted Cloud service over HTTPS. No data file
+  to manage and no on-premise binary to update; suitable for teams who want
+  the fastest path to a working integration. See
+  @ref IpIntelligence_Examples_GettingStarted_Web_Cloud.
+
+- **On-premise** — runs the IP Intelligence engine inside your own process
+  against a locally distributed data file. Suitable for workloads that need
+  offline operation, predictable latency, or the highest request throughput.
+  See @ref IpIntelligence_Examples_GettingStarted_Web_OnPremise.
+
+Both examples follow the same shape: configure a pipeline, register it with
+the framework, hand it the request and read the detected properties off the
+result. Snippets are shown side by side for ASP.NET Core, Java, Node.js, PHP
+and Python so you can pick the language that matches your stack. For console
+or batch-style integrations, see @ref IpIntelligence_Examples_GettingStarted_Console_Index
+instead.
 
 @subpage IpIntelligence_Examples_GettingStarted_Web_Cloud
 

--- a/src/ipintelligence/examples/gettingstartedweb/index.md
+++ b/src/ipintelligence/examples/gettingstartedweb/index.md
@@ -21,7 +21,7 @@ Two deployment models are covered:
   offline operation, predictable latency, or the highest request throughput.
   See @ref IpIntelligence_Examples_GettingStarted_Web_OnPremise.
 
-Both examples follow the same shape: configure a pipeline, register it with
+Both examples follow the same pattern: configure a pipeline, register it with
 the framework, hand it the request and read the detected properties off the
 result. Snippets are shown side by side for ASP.NET Core, Java, Node.js, PHP
 and Python so you can pick the language that matches your stack. For console


### PR DESCRIPTION
## Summary

The Getting Started landing pages under `src/devicedetection/examples/` and `src/ipintelligence/examples/` are single-line stubs containing only `@subpage` directives. When Doxygen renders them they produce HTML with ~60 words total, most of it nav. The 2026-06 Semrush audit on 51degrees.com lists them at the very top of the "issue pages" report:

| Page | Words | Issues |
|---|---|---|
| `/documentation/_device_detection__examples__getting_started__web__index.html` | 61 | 117, 102, 39, 213 |
| `/documentation/_device_detection__examples__getting_started__console__index.html` | 61 | 117, 102, 39, 213 |
| `/documentation/_device_detection__examples__performance__index.html` | 56 | 117, 102, 39, 213 |
| `/documentation/_ip_intelligence__examples__getting_started__web__index.html` | 61 | 117, 102, 113, 39, 213 |
| `/documentation/_ip_intelligence__examples__getting_started__console__index.html` | 61 | 117, 102, 113, 39, 213 |

The two IP Intelligence pages additionally trip rule **113 Duplicate title** because their `@page` titles are identical to the Device Detection variants (`Getting Started - Web`, `Getting Started - Console`), which produces identical `<title>` and identical template-derived `<meta name="description">`.

## Changes

For each of the five files: open with an `# Introduction` section that explains what the example demonstrates, when to pick Cloud vs On-premise, which languages ship side-by-side snippets, and links to the most relevant related pages. The `@subpage` directives are preserved at the bottom of each file so the Doxygen nav tree is unchanged.

The two IP Intelligence landing pages now carry the suffix `(IP Intelligence)` in their `@page` title so they no longer collide with the Device Detection variants.

All `@ref` targets were verified against existing `@page` IDs in `src/`:

- `DeviceDetection_Features_UACH_Overview` (defined in `src/devicedetection/features/useragentclienthints/index.md`)
- `DeviceDetection_Features_PerformanceOptions` (defined in `src/devicedetection/features/performanceoptions.md`)
- `DeviceDetection_CloudToOnPremise` (defined in `src/devicedetection/cloudtoonpremise.md`)
- `DeviceDetection_Examples_GettingStarted_Web_Index`, `_Console_Index` (defined in this PR / unchanged)
- `IpIntelligence_Examples_GettingStarted_Web_Cloud`, `_OnPremise`, `_Console_Cloud`, `_Console_OnPremise` (defined in the cloud.md / onpremise.md siblings)

## Semrush checks closed (5 pages each)

| Check | Description |
|---|---|
| 117 | Too few words on the page |
| 102 | Missing meta description |
| 113 | Duplicate title tags |
| 39 / 213 | Low text-to-HTML ratio |

## What this PR does not cover

- **Rule 12 / 122 (`__` double-underscore URLs).** Already triaged in #143 as wontfix, with the underscores tracking the Doxygen `@page` group structure.
- **The thin pages under `src/ipintelligence/combined/`, `src/pipelineapi/concepts/`, etc.** They follow the same stub pattern but were not flagged at the top of the current Semrush report; we can roll them in as a follow-up once the impact of this PR has been measured in the next audit.
- **The OpenRTB Mappings page (`_product_summaries__open_r_t_b_mappings.html`).** Healthy word count (1,200) but flagged for the template-derived short meta description. That is a `header.html` template issue and is better addressed across all pages in a separate PR.

## Test plan

- [ ] Re-run the `Build Documentation` workflow on this branch
- [ ] Confirm each of the five output pages now has > 200 words of body content
- [ ] Confirm `meta name="description"` is no longer identical to other pages (Doxygen synthesises it from `$title`; the IP Intelligence variants now have distinct titles)
- [ ] Re-run Semrush on `/documentation/_device_detection__examples__getting_started__*_index.html` after the next gh-pages publish and confirm checks 117 / 102 / 113 / 39 / 213 clear for those 5 pages

## Related

- #139 (meta description template at source)
- #154 / #155 (heading hierarchy fixes)
- #143 (wontfix: underscore URLs)
- 51Degrees/Website Semrush issue-pages dashboard