### PR TITLE
header: drop unused dynsections.js, load codefolding.js conditionally

### DIFF
--- a/docs/header.html
+++ b/docs/header.html
@@ -16,7 +16,9 @@
 $extrastylesheet
 <style type="text/css">.c-brand__image{aspect-ratio:360/67}@media (max-width:992px){.l-docs-index .g-docs__sidenav .c-sidenav{min-height:600px}}</style>
 <script type="text/javascript" src="$relpath^jquery.js"></script>
-<script type="text/javascript" src="$relpath^dynsections.js"></script>
+<!--BEGIN HTML_CODE_FOLDING-->
+<script type="text/javascript" src="$relpath^codefolding.js"></script>
+<!--END HTML_CODE_FOLDING-->
 <script type="text/javascript" src="$relpath^examplegrabber.js"></script>
 <script type="text/javascript" src="$relpath^testedversionsgrabber.js"></script>
 <script type="text/javascript" src="$relpath^search51.js"></script>


### PR DESCRIPTION
The custom HTML header (ported from doxygen 1.8) referenced dynsections.js unconditionally, but HTML_DYNAMIC_SECTIONS is off so doxygen never generates that file, causing a 404. Dynamic sections are not used anywhere in the docs, so remove the reference entirely.

Also guard the codefolding.js include behind HTML_CODE_FOLDING (matching doxygen's own default header) so it is only loaded when the feature is enabled, avoiding a "codefold is not defined" error.