### PR TITLE
fix(content): use descriptive link anchor text (SEMrush 217)

### DIFF
--- a/src/devicedetection/features/useragentclienthints/overview.md
+++ b/src/devicedetection/features/useragentclienthints/overview.md
@@ -104,7 +104,7 @@ UA-CH offers several mechanisms for accessing values. This section explains our 
 ## How UA-CH works
 
 
-The authors of the proposal have created an [article](https://web.dev/user-agent-client-hints) covering how UA-CH works.
+The authors of the proposal have written [a web.dev guide to how UA-CH works](https://web.dev/user-agent-client-hints).
 
 51Degrees has [blogged extensively](https://51degrees.com/resources/blogs/tag/Client%20Hints) on the subject. We also have:
 

--- a/src/devicedetection/otherintegrations/nginx.md
+++ b/src/devicedetection/otherintegrations/nginx.md
@@ -8,7 +8,7 @@ We have also integrated our Device Detection to Nginx. This page describes in de
 For the latest tested versions and tested platforms information, please refer to our @testedversions page.
 
 # Installing
-If you haven’t already, you can obtain a copy of the latest version of the API [here](https://github.com/51Degrees/device-detection-nginx).
+If you haven’t already, you can obtain the latest version of the API from the [device-detection-nginx repository](https://github.com/51Degrees/device-detection-nginx).
 
 To build the module only, run the following command. This will output to `ngx_http_51D_module.so` in the `build/modules` directory.
 ```

--- a/src/devicedetection/otherintegrations/varnish.md
+++ b/src/devicedetection/otherintegrations/varnish.md
@@ -8,7 +8,7 @@ We have also integrated our Device Detection to Varnish. This page details an ov
 For the latest tested versions and tested platforms information, please refer to our @testedversions page.
 
 # Installing
-If you haven’t already, you can obtain a copy of the latest version of the API [here](https://github.com/51Degrees/device-detection-varnish).
+If you haven’t already, you can obtain the latest version of the API from the [device-detection-varnish repository](https://github.com/51Degrees/device-detection-varnish).
 To install on a Linux system, run the following commands from the project's root directory.
 
 ```

--- a/src/devicedetection/otherintegrations/wordpress.md
+++ b/src/devicedetection/otherintegrations/wordpress.md
@@ -129,7 +129,7 @@ The WordPress plugin will handle this for you automatically. However, be aware t
 
 If you want to build the plugin yourself and install locally, you will need to follow these steps:
 
-1.  Clone 51Degrees plugin GitHub repository from [here](https://github.com/51Degrees/pipeline-wordpress/).
+1.  Clone the [51Degrees WordPress plugin repository](https://github.com/51Degrees/pipeline-wordpress/).
 
 2.  Execute `composer install` in the `lib` directory.
 

--- a/src/productsummaries/openrtbmappings.md
+++ b/src/productsummaries/openrtbmappings.md
@@ -2,7 +2,7 @@
 
 # Introduction
 
-The RTB Project is an API specification for companies needing an open protocol for the automated trading of digital media across a broader range of platforms, devices, and advertising solutions. To aid those wishing to enhance the capture of device data, we've compiled a guide to map OpenRTB Object: Device and Geo fields to 51Degrees properties and values. The full Open RTB API Specification can be found [here](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md) with the Device Object specification in section [3.2.18](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md#3218---object-device-) and Geo Object specification in section [3.2.19](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md#3219---object-geo-).
+The RTB Project is an API specification for companies needing an open protocol for the automated trading of digital media across a broader range of platforms, devices, and advertising solutions. To aid those wishing to enhance the capture of device data, we've compiled a guide to map OpenRTB Object: Device and Geo fields to 51Degrees properties and values. The full Open RTB API Specification can be found in [the OpenRTB 2.6 specification](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md) with the Device Object specification in section [3.2.18](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md#3218---object-device-) and Geo Object specification in section [3.2.19](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md#3219---object-geo-).
 
 # OpenRTB API Device Mappings
 

--- a/src/services/cloud/overview.md
+++ b/src/services/cloud/overview.md
@@ -7,7 +7,7 @@ There are a couple methods to integrate the Cloud Service, but regardless of the
 # RESTful API
 
 
-In the most raw form Cloud Service is accessible via RESTful API that is documented [here](https://cloud.51degrees.com/api-docs/index.html).
+In the most raw form Cloud Service is accessible via a RESTful API, documented in the [Cloud REST API reference](https://cloud.51degrees.com/api-docs/index.html).
 
 ---
 


### PR DESCRIPTION
Reword link anchor text so it describes the destination instead of saying "here" or "article" (SEMrush issue 217). URLs are unchanged; only visible link text and minimal surrounding wording were adjusted.

Reworded anchors:

- `src/services/cloud/overview.md`: "documented [here]" -> "documented in the [Cloud REST API reference]"
- `src/productsummaries/openrtbmappings.md`: "can be found [here]" -> "can be found in [the OpenRTB 2.6 specification]" (3.2.18 / 3.2.19 links unchanged)
- `src/devicedetection/otherintegrations/wordpress.md`: "Clone 51Degrees plugin GitHub repository from [here]" -> "Clone the [51Degrees WordPress plugin repository]"
- `src/devicedetection/otherintegrations/varnish.md`: "obtain a copy of the latest version of the API [here]" -> "obtain the latest version of the API from the [device-detection-varnish repository]"
- `src/devicedetection/otherintegrations/nginx.md`: "obtain a copy of the latest version of the API [here]" -> "obtain the latest version of the API from the [device-detection-nginx repository]"
- `src/devicedetection/features/useragentclienthints/overview.md`: "created an [article] covering how UA-CH works" -> "written [a web.dev guide to how UA-CH works]"