### PR TITLE
fix(content): make IP Intelligence example page titles unique (SEMrush 15)

### DIFF
--- a/src/devicedetection/otherintegrations/openrtbmappings.md
+++ b/src/devicedetection/otherintegrations/openrtbmappings.md
@@ -1,4 +1,4 @@
-@page DeviceDetection_OtherIntegrations_OpenRTBMappings OpenRTB Mappings
+@page DeviceDetection_OtherIntegrations_OpenRTBMappings OpenRTB Mappings (Moved)
 
 # Location Changed
 

--- a/src/ipintelligence/examples/datafileupdates.md
+++ b/src/ipintelligence/examples/datafileupdates.md
@@ -1,4 +1,4 @@
-@page IpIntelligence_Examples_DataFileUpdates Data File Updates
+@page IpIntelligence_Examples_DataFileUpdates IP Intelligence Data File Updates
 
 @startsnippets
 @grabexample{ip-intelligence-dotnet,_on_premise_2_update_data_file-_console_2_program_8cs,C#}

--- a/src/ipintelligence/examples/gettingstartedconsole/cloud.md
+++ b/src/ipintelligence/examples/gettingstartedconsole/cloud.md
@@ -1,4 +1,4 @@
-@page IpIntelligence_Examples_GettingStarted_Console_Cloud Getting Started Console Cloud
+@page IpIntelligence_Examples_GettingStarted_Console_Cloud IP Intelligence Getting Started Console Cloud
 
 # Introduction
 

--- a/src/ipintelligence/examples/gettingstartedconsole/index.md
+++ b/src/ipintelligence/examples/gettingstartedconsole/index.md
@@ -1,4 +1,4 @@
-@page IpIntelligence_Examples_GettingStarted_Console_Index Getting Started - Console (IP Intelligence)
+@page IpIntelligence_Examples_GettingStarted_Console_Index IP Intelligence Getting Started Console
 
 # Introduction
 

--- a/src/ipintelligence/examples/gettingstartedconsole/onpremise.md
+++ b/src/ipintelligence/examples/gettingstartedconsole/onpremise.md
@@ -1,4 +1,4 @@
-@page IpIntelligence_Examples_GettingStarted_Console_OnPremise Getting Started Console On-premise
+@page IpIntelligence_Examples_GettingStarted_Console_OnPremise IP Intelligence Getting Started Console On-premise
 
 # Introduction
 

--- a/src/ipintelligence/examples/gettingstartedweb/cloud.md
+++ b/src/ipintelligence/examples/gettingstartedweb/cloud.md
@@ -1,4 +1,4 @@
-@page IpIntelligence_Examples_GettingStarted_Web_Cloud Getting Started Web Cloud
+@page IpIntelligence_Examples_GettingStarted_Web_Cloud IP Intelligence Getting Started Web Cloud
 
 # Introduction
 

--- a/src/ipintelligence/examples/gettingstartedweb/index.md
+++ b/src/ipintelligence/examples/gettingstartedweb/index.md
@@ -1,4 +1,4 @@
-@page IpIntelligence_Examples_GettingStarted_Web_Index Getting Started - Web (IP Intelligence)
+@page IpIntelligence_Examples_GettingStarted_Web_Index IP Intelligence Getting Started Web
 
 # Introduction
 

--- a/src/ipintelligence/examples/gettingstartedweb/onpremise.md
+++ b/src/ipintelligence/examples/gettingstartedweb/onpremise.md
@@ -1,4 +1,4 @@
-@page IpIntelligence_Examples_GettingStarted_Web_OnPremise Getting Started Web On-premise
+@page IpIntelligence_Examples_GettingStarted_Web_OnPremise IP Intelligence Getting Started Web On-premise
 
 # Introduction
 

--- a/src/ipintelligence/examples/metadata.md
+++ b/src/ipintelligence/examples/metadata.md
@@ -1,4 +1,4 @@
-@page IpIntelligence_Examples_Metadata Metadata
+@page IpIntelligence_Examples_Metadata IP Intelligence Metadata
 
 @startsnippets
 @grabexample{ip-intelligence-cxx,_ip_intelligence_2_meta_data_8cpp,C++}

--- a/src/ipintelligence/examples/offlineprocessing.md
+++ b/src/ipintelligence/examples/offlineprocessing.md
@@ -1,4 +1,4 @@
-@page IpIntelligence_Examples_OfflineProcessing Offline Processing
+@page IpIntelligence_Examples_OfflineProcessing IP Intelligence Offline Processing
 
 @startsnippets
 @grabexample{ip-intelligence-cxx,_ip_intelligence_2_offline_processing_8c,C}

--- a/src/ipintelligence/examples/performance.md
+++ b/src/ipintelligence/examples/performance.md
@@ -1,4 +1,4 @@
-@page IpIntelligence_Examples_Performance Performance
+@page IpIntelligence_Examples_Performance IP Intelligence Performance
 
 @startsnippets
 @grabexample{ip-intelligence-cxx,_ip_intelligence_2_performance_8c,C}


### PR DESCRIPTION
## What

Resolves duplicate `<title>` tags (SEMrush 15) and reduces duplicate content (SEMrush 6): the IP Intelligence example pages previously shared identical titles with their Device Detection counterparts.

## Changes

- Product-qualified the IP Intelligence example page titles (page ids unchanged), e.g. `Performance` -> `IP Intelligence Performance`, across `performance.md`, `metadata.md`, `offlineprocessing.md`, `datafileupdates.md`, and the `gettingstartedweb` / `gettingstartedconsole` cloud and on-premise pages.
- Aligned the two IPI Getting Started index pages to the same prefix style: `Getting Started - Web (IP Intelligence)` -> `IP Intelligence Getting Started Web`, and the Console equivalent.
- Retitled the OpenRTB stub (`devicedetection/otherintegrations/openrtbmappings.md`) to `OpenRTB Mappings (Moved)` so it no longer collides with the Product Summaries page.

Only the human-readable titles changed; `@page` ids and anchors are untouched, so cross-references still resolve.