### PR TITLE
fix(build): disable FULL_PATH_NAMES to shorten Doxygen page titles (SEMrush 102)

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -163,7 +163,7 @@ INLINE_INHERITED_MEMB  = NO
 # shortest path that makes the file name unique will be used
 # The default value is: YES.
 
-FULL_PATH_NAMES        = YES
+FULL_PATH_NAMES        = NO
 
 # The STRIP_FROM_PATH tag can be used to strip a user-defined part of the path.
 # Stripping is only done if one of the specified strings matches the left-hand


### PR DESCRIPTION
## Problem (SEMrush issue 102 "title element is too long", 88 pages)

Doxygen generates directory-reference and file pages (`dir_*.html`) whose `<title>` embedded the full CI build path, for example:

`51Degrees API Documentation: /home/runner/work/documentation/documentation/src/pipelineapi/concepts Directory Reference`

This was caused by `FULL_PATH_NAMES = YES` in `docs/Doxyfile`, which makes Doxygen prepend the full filesystem path to file and directory names. On CI the working directory is a long `/home/runner/work/...` path, so it leaked into the page titles and pushed them over the recommended length.

## Fix

Set `FULL_PATH_NAMES = NO` in `docs/Doxyfile`. Doxygen then uses the shortest path that makes each name unique, so the titles become short (e.g. just the directory name + "Directory Reference"), clearing the over-length-title finding.

## Scope

The change applies uniformly to all Doxygen output, including the API repos that share this same config. No content or behaviour beyond title/path display is affected. `STRIP_FROM_PATH` is left empty (its default), and it only applies when `FULL_PATH_NAMES = YES`, so it has no effect after this change.