### PR TITLE
fix(content): resolve duplicate H1 on Performance Options page (SEMrush 104)

### DIFF
--- a/src/devicedetection/features/performanceoptions.md
+++ b/src/devicedetection/features/performanceoptions.md
@@ -33,7 +33,7 @@ The precise values associated with each template can be seen in the source code 
 
 In version 4.5 and later, the device detection algorithm uses a single, unified predictive graph. Previously, it was possible to select between performance and predictive graphs, but these have been consolidated to provide the best balance of speed and accuracy.
 
-# Property Indexing {#faster-property-retrieval}
+# Property Indexing
 
 A configuration option `propertyValueIndex` is available (introduced in version 4.5). 
 When enabled (set to `true`), the engine indexes property values at startup.


### PR DESCRIPTION
## What I found

Fetching the live rendered page confirmed it emits two `<h1>` elements:

```
70:<h1 class="g-docs__page-title">Performance Options </h1>
73:<h2 class="g-docs__section-heading">Introduction</h2>
77:<h2 class="g-docs__section-heading">Performance profile templates</h2>
95:<h2 class="g-docs__section-heading">Evaluation graphs</h2>
97:<h1 class="doxsection"><a class="anchor" id="faster-property-retrieval"></a>
101:<h2 class="g-docs__section-heading">Restrict properties</h2>
```

The page title (line 70) is the intended single `<h1>`. Every `#` section heading renders as `<h2 class="g-docs__section-heading">` except one: the `# Property Indexing {#faster-property-retrieval}` heading, which renders as `<h1 class="doxsection">` (line 97).

## Root cause

The custom Doxygen anchor `{#faster-property-retrieval}` on that heading routes it through Doxygen's `doxsection` code path, which emits `<h1 class="doxsection">` with an embedded anchor element rather than the normal section-heading `<h2>`. That is the SEMrush "multiple H1 tags" second heading.

## The fix and why it is minimal

Removed the `{#faster-property-retrieval}` suffix so the heading reads simply `# Property Indexing`, matching every other section heading on the page. It now renders as `<h2 class="g-docs__section-heading">`, leaving the page title as the only `<h1>`. This is a one-line change that alters no visible content.

## Was the anchor referenced?

No. A search for `faster-property-retrieval` across `src/` and the cloned API example repos under `apis/` found only the heading's own definition line. Removing the anchor therefore breaks no cross-reference, so preserving it via an alternative anchor form was unnecessary.