### PR TITLE
fix(build): noindex generated scaffolding pages + remove graph legend (SEMrush 102/112/117/213/216/222)

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1609,6 +1609,20 @@ DISABLE_INDEX          = YES
 
 GENERATE_TREEVIEW      = YES
 
+# If the HTML_INDEX_NOINDEX tag is set to YES then doxygen adds a
+# <meta name="robots" content="noindex,follow"> tag to the generated
+# navigation, index and helper pages (the tab indexes, the per-directory
+# reference pages, the graph legend and the crawler helper page). These thin,
+# link-only pages stay out of the search index while crawlers still follow
+# their links to the real documentation. The main page and ordinary
+# documentation pages are unaffected. Requires the 51Degrees DoxyGen build
+# that ships this option (see 51Degrees/doxygen#7); older builds ignore it
+# with a harmless warning.
+# The default value is: NO.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+HTML_INDEX_NOINDEX     = YES
+
 # The HIDE_TREEVIEW_ROOT tag is used to remove the root node from the tree view.
 # When not hidden, the tree root will be PROJECT_NAME. If the tree root is set
 # to hidded then the tree will only contain tree defined in the layout.

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2654,7 +2654,7 @@ DOT_MULTI_TARGETS      = NO
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-GENERATE_LEGEND        = YES
+GENERATE_LEGEND        = NO
 
 # If the DOT_CLEANUP tag is set to YES, doxygen will remove the intermediate dot
 # files that are used to generate the various graphs.


### PR DESCRIPTION
## What

Addresses B5 of the SEMrush documentation audit: Doxygen's auto-generated scaffolding pages (`dir_*.html`, `pages.html`, `graph_legend.html`, `doxygen_crawl.html`) are thin, link-only pages with no SEO value, yet they drive a large share of the findings on `/documentation/*`:

- 102 (title too long), 112 (low text-to-HTML ratio), 117 (missing alt) on the 43 `dir_*.html` directory-reference pages
- 213 / 216 / 222 notices on `graph_legend.html`, `pages.html`, `doxygen_crawl.html`

The fix is done at the DoxyGen-generation level (not by patching the generated HTML in CI).

## Changes in this PR (`docs/Doxyfile`)

1. `GENERATE_LEGEND = NO` - stops emitting `graph_legend.html` entirely. Verified with the bundled DoxyGen build that the page is gone and nothing links to it (no broken links).
2. `HTML_INDEX_NOINDEX = YES` - enables the new option added in **51Degrees/doxygen#7**, which tags the remaining generated index/helper pages (`dir_*.html`, `pages.html`, `doxygen_crawl.html`) with `<meta name="robots" content="noindex,follow">`. Crawlers still follow the links to the real docs; the index pages drop out of the search index.

## Why a DoxyGen change was needed

I built the docs with the real DoxyGen binary and tested every Doxyfile lever first. None of `SHOW_FILES`, `DIRECTORY_GRAPH`, `EXTERNAL_SEARCH` or `SERVER_BASED_SEARCH` suppress or noindex the `dir_*.html` / `pages.html` / `doxygen_crawl.html` pages, and the shared `header.html` template cannot carry a per-page `noindex`. So the capability had to be added to DoxyGen itself, as the configurable, upstreamable option in 51Degrees/doxygen#7 (default off, so it is backwards compatible).

Verification of the new binary against this docs set: with the option on, `noindex,follow` lands on all 43 `dir_*.html`, on `pages.html` and on `doxygen_crawl.html`, and is absent from `index.html` and every content page (0 content pages affected). With the option off, output is unchanged.

## Merge ordering

`GENERATE_LEGEND = NO` is effective immediately. `HTML_INDEX_NOINDEX = YES` only takes effect once 51Degrees/doxygen#7 is merged, the Linux binary rebuilt, and promoted to `51Degrees/tools/DoxyGen/doxygen-linux.zip`. Until then the deployed binary ignores the tag with a harmless warning (`WARN_AS_ERROR = NO`), so this PR is safe to land beforehand.