### PR TITLE
style(footer): centre the docs footer and enlarge the CTA

### DIFF
--- a/pattern-library/source/sass/03-groups/05-footers/00-footer.scss
+++ b/pattern-library/source/sass/03-groups/05-footers/00-footer.scss
@@ -11,8 +11,14 @@
 
   &--docs {
     border-top: none;
+    text-align: center;
     a {
       @include make-link-docs();
+    }
+    // The docs footer is a call to action rather than fine print, so it is
+    // centred and set a step larger than the default copyright text.
+    .g-footer__message {
+      font-size: size(0);
     }
   }
 }


### PR DESCRIPTION
Within the `.g-footer--docs` variant (the documentation footer, which is now a support call to action), centre the content (`text-align: center`) and set the message one step larger than the default copyright size (`font-size: size(0)`).

Scoped to `--docs` so the main 51degrees.com site footer is unaffected. Change is in the pattern library SCSS (`pattern-library/.../00-footer.scss`); `docs/docs-main.css` is regenerated from it by `ci/build-pattern-library.ps1` on the next documentation build.