### PR TITLE
fix(docs): remove stale 'doxygen 1.8.15' marker comments

### DIFF
--- a/docs/footer.html
+++ b/docs/footer.html
@@ -1,4 +1,3 @@
-<!-- HTML footer for doxygen 1.8.15-->
 <!-- start footer part -->
 <!--BEGIN GENERATE_TREEVIEW-->
 <section id="nav-path" class="g-footer g-footer--docs"><!-- id is needed for treeview function! -->

--- a/docs/header.html
+++ b/docs/header.html
@@ -1,4 +1,3 @@
-<!-- HTML header for doxygen 1.8.15-->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>


### PR DESCRIPTION
`docs/header.html` and `docs/footer.html` each started with a hardcoded `<!-- HTML header/footer for doxygen 1.8.15-->` marker from when the templates were first generated. The build uses DoxyGen 1.17.0, so that comment showed a wrong version on every generated page. Removed both stale markers. The accurate `Generated by doxygen 1.17.0` comment is unaffected.