### PR TITLE
Emit lang and website masthead from the DoxyGen header

### DIFF
--- a/docs/HEADER-NOTES.md
+++ b/docs/HEADER-NOTES.md
@@ -65,8 +65,9 @@ The inline `<style>` block reserves two layout boxes ahead of asset
 arrival to keep Cumulative Layout Shift near zero:
 
 - `.c-brand__image { aspect-ratio: 360/67 }` matches the natural
-  dimensions of `/img/logo.png` (the file the website proxy swaps in
-  for `logo-51Degrees-Docs.png` on 51degrees.com). The `<img>` element
+  dimensions of `https://51degrees.com/img/logo.png`, the brand logo the
+  masthead `<img>` now references directly (see the masthead section
+  below). The `<img>` element
   also gets matching `width="360" height="67"` attributes for browsers
   that honour the attribute-derived aspect ratio rather than the CSS
   one. Without the reservation the masthead first paints with a zero-
@@ -128,6 +129,34 @@ the mirror loop and rewrites three things by regex:
 Doing this in CI rather than patching the template lets the same
 rule apply uniformly across every API repo's doxygen output without
 needing each one to re-pull a template change.
+
+## Why `<html>` carries `lang="en"` and the masthead points at the website
+
+Two shapes are set directly in the template so DoxyGen emits them on
+every page (this header is the shared `HTML_HEADER` for every API repo's
+Doxyfile, so one change covers them all), removing the need for the
+51degrees.com reverse proxy to patch the rendered HTML at request time:
+
+- `<html ... lang="en">`. DoxyGen omits `lang`; declaring it once here
+  gives every page the document-language signal screen readers and
+  search engines expect. The proxy used to inject this per request.
+
+- The masthead links to the website and uses the shared brand logo:
+  `<a href="https://51degrees.com/">` wrapping
+  `<img src="https://51degrees.com/img/logo.png">`. The URLs are
+  absolute (not `$projecturl` / `$relpath^$projectlogo`) so they resolve
+  identically whether the page is served through the site or directly
+  from gh-pages, and the logo request doubles as the analytics pixel
+  when served from 51degrees.com. The proxy used to swap the logo and
+  rewrite the home link per request. DoxyGen's own "Main Page" nav links
+  stay relative, so in-docs navigation still points at the docs index
+  rather than the marketing home.
+
+Canonical, hreflang and the page-title/heading rebalancing stay in CI
+(see the sections above) because the template cannot construct those
+from DoxyGen substitutions; eliminating the proxy's remaining canonical
+/ hreflang / title rewrites needs a feature in the custom 51Degrees
+DoxyGen build, not a template change.
 
 ## Why these notes are not inline comments
 

--- a/docs/header.html
+++ b/docs/header.html
@@ -1,6 +1,6 @@
 <!-- HTML header for doxygen 1.8.15-->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
 <meta http-equiv="X-UA-Compatible" content="IE=9"/>
@@ -34,7 +34,7 @@ $mathjax
 <div id="titlearea" class="g-header g-header--docs">
   <div class="c-brand" role="banner">
   <!--BEGIN PROJECT_LOGO-->
-  <a id="projectlogo" href="$projecturl" class="c-brand__link"><img class="c-brand__image" alt="Logo" src="$relpath^$projectlogo" width="360" height="67" style="width:172px;height:auto;"/></a>
+  <a id="projectlogo" href="https://51degrees.com/" class="c-brand__link"><img class="c-brand__image" alt="51Degrees" src="https://51degrees.com/img/logo.png" width="360" height="67" style="width:172px;height:auto;"/></a>
   <!--BEGIN PROJECT_NAME-->
   <span class="c-tagline">$projectname
    <!--BEGIN PROJECT_NUMBER-->&#160;<span id="projectnumber">$projectnumber</span><!--END PROJECT_NUMBER-->


### PR DESCRIPTION
Makes DoxyGen emit clean HTML for three things the 51degrees.com reverse proxy currently patches at request time, by setting them in the shared `docs/header.html` (the `HTML_HEADER` every API repo's Doxyfile references, so one change covers all generated pages):

- `<html lang="en">` (DoxyGen omits `lang`)
- masthead logo `src` -> `https://51degrees.com/img/logo.png` (the brand logo, which also serves as the analytics pixel when served from 51degrees.com)
- masthead link `href` -> `https://51degrees.com/` (the site home)

URLs are absolute so they resolve identically via the site or directly from gh-pages. DoxyGen's own "Main Page" nav links stay relative, so in-docs navigation still points at the docs index rather than the marketing home. Rationale is in `HEADER-NOTES.md` (not inline, per #141).

### Approach
This replaces the closed #187, which did the same in `ci/generate-documentation.ps1`. Per direction, the fix belongs in DoxyGen so it emits clean HTML, not in a CI post-processing pass over generated HTML.

### Companion / sequencing
- Enables a Website `ProxyHandler` PR that drops `SetLang`, the logo swap, the `index.html`->`/` rewrite, and the obsolete "Coming soon" `ToRemove[]` strip (those features are now documented).
- **Merge order:** this must merge and the docs rebuild + go live **before** the Website PR deploys, or those pages regress.
- No file overlap with #185 (Doxyfile/SCSS/`src/*.md`).

### Out of scope (needs the custom DoxyGen build, not a template change)
Canonical, hreflang and the member-list `<title>` cannot be built from DoxyGen substitutions (see HEADER-NOTES.md "Why hreflang lives in the CI script"). Eliminating the proxy's remaining canonical/hreflang/title rewrites needs a feature in the custom 51Degrees DoxyGen build; tracked separately.
