### PR TITLE
fix(ci): mirror image assets to the unversioned root (fixes broken diagrams in #186)

### DIFF
--- a/ci/generate-documentation.ps1
+++ b/ci/generate-documentation.ps1
@@ -163,8 +163,35 @@ Get-ChildItem -Recurse -File -Filter "*.html" -Path "gh-pages/$version" | ForEac
     Set-Content -Path $dest -Value $content -NoNewline
     $mirrored.Add($rel)
 }
+
+# Mirror image assets to the unversioned root as well. The HTML mirror above
+# relies on <base href="/documentation/$version/"> so relative asset references
+# resolve back into the versioned tree, but a downstream host (the 51degrees.com
+# reverse proxy) does not always preserve <base>. Doxygen references content
+# images and SVG graphs by basename (e.g. diagrams embedded as
+# <object data="...svg">), so without the base they resolve to the unversioned
+# root and 404 -- the proxy then serves an HTML fallback, which the browser
+# cannot render as an image, so the diagram shows blank. Copy the image assets
+# up so the mirrored pages are self-contained regardless of <base>. Skip any
+# that already exist at the root (global theme/doxygen assets are placed there
+# separately) and record what we add so the stale-mirror cleanup at the top of
+# this step removes them on the next run.
+$assetExtensions = '.svg', '.png', '.jpg', '.jpeg', '.gif', '.webp', '.ico'
+$assetsCopied = 0
+Get-ChildItem -Recurse -File -Path "gh-pages/$version" |
+    Where-Object { $assetExtensions -contains $_.Extension.ToLowerInvariant() } |
+    ForEach-Object {
+        $rel = $_.FullName.Substring($srcRoot.Length + 1) -replace '\\', '/'
+        $dest = Join-Path "gh-pages" $rel
+        if (-not (Test-Path $dest)) {
+            New-Item -ItemType Directory -Force (Split-Path $dest) | Out-Null
+            Copy-Item -Force $_.FullName $dest
+            $mirrored.Add($rel)
+            $assetsCopied++
+        }
+    }
 Set-Content -Path $manifestPath -Value ($mirrored -join "`n")
-Write-Host "Mirrored $($mirrored.Count) HTML files to gh-pages root, added canonical to $canonicalsAdded versioned files, added hreflang to $hreflangsAdded versioned files."
+Write-Host "Mirrored $($mirrored.Count - $assetsCopied) HTML files and $assetsCopied image assets to gh-pages root, added canonical to $canonicalsAdded versioned files, added hreflang to $hreflangsAdded versioned files."
 Write-Host "::endgroup::"
 
 # Minify the Doxygen-emitted JS (jquery.js, navtree.js, dynsections.js,


### PR DESCRIPTION
## Problem
On the proxied/unversioned production URLs, content images and SVG graphs render blank — e.g. the three diagrams on the **Apple Model Detection** page (#186).

**Root cause:** the unversioned mirror pages rely on `<base href="/documentation/<version>/">` so relative asset refs resolve back into the versioned tree. The 51degrees.com reverse proxy does **not** preserve `<base>`. Doxygen references content images and SVG graphs by basename (e.g. `<object data="51D-detection-example-1.svg">`), so without the base they resolve to the unversioned root, 404, and the proxy serves an HTML fallback (`200 text/html`) in their place — which the browser can't render as an image.

Verified: `https://51degrees.com/documentation/51D-detection-example-1.svg` → `200 text/html` (broken); the real asset lives only at `…/documentation/4.5/51D-detection-example-1.svg` → `200 image/svg+xml`.

## Fix
In `ci/generate-documentation.ps1`, the mirror step now copies image assets (`svg/png/jpg/jpeg/gif/webp/ico`) from the versioned tree up to the unversioned root, preserving relative paths, so the mirrored pages are self-contained regardless of whether `<base>` survives downstream.

- Skips assets already present at the root (global theme/doxygen assets placed there separately are not clobbered).
- Records copied files in `.mirror-manifest` so the existing stale-mirror cleanup removes them on the next run (idempotent).

Since `DOT_IMAGE_FORMAT = svg` with graphs enabled, this also fixes doxygen graph SVGs on any mirrored page, not just the Apple content diagrams.

## Validation
- PowerShell parses clean; copy logic unit-tested in isolation (correct count, nested-path preservation, skip-existing).
- Preview build on this PR will be checked to confirm the SVGs resolve at the unversioned root before merge.
- After merge, gh-pages is rebuilt (`build.yml` dispatch) and production verified, then #186 closed with a screenshot.

Addresses #186.