### PR TITLE
style(footer): enlarge the docs footer CTA

### DIFF
--- a/pattern-library/source/sass/03-groups/05-footers/00-footer.scss
+++ b/pattern-library/source/sass/03-groups/05-footers/00-footer.scss
@@ -16,9 +16,13 @@
       @include make-link-docs();
     }
     // The docs footer is a call to action rather than fine print, so it is
-    // centred and set a step larger than the default copyright text.
+    // centred (text-align above) and set noticeably larger than the default
+    // copyright text, stepping up again on wider screens so the CTA stands out.
     .g-footer__message {
-      font-size: size(0);
+      font-size: size(1);
+      @include respond-to(md) {
+        font-size: size(2);
+      }
     }
   }
 }


### PR DESCRIPTION
Makes the documentation footer call-to-action larger so it reads as a prompt rather than fine print. Already centred via .g-footer--docs; steps the font from size(0) to size(1), and size(2) on md+ screens. Pattern-library SCSS only; takes effect on the next docs rebuild.