### PR TITLE
style(docs): remove underline from heading permalink glyph on hover

### DIFF
--- a/pattern-library/source/sass/04-layouts/01-docs/00-docs-index.scss
+++ b/pattern-library/source/sass/04-layouts/01-docs/00-docs-index.scss
@@ -157,6 +157,12 @@
       text-decoration: none;
       opacity: 0;
       transition: opacity 0.15s ease;
+      // The permalink glyph inherits the docs link styling, which underlines
+      // on hover/focus. Keep the glyph clean (no underline under the icon).
+      &:hover,
+      &:focus {
+        text-decoration: none;
+      }
     }
     &:hover .headerlink,
     .headerlink:focus {


### PR DESCRIPTION
The heading permalink icon inherits the docs link style, which underlines on hover/focus, putting an underscore under the glyph. This forces text-decoration:none on .headerlink:hover/:focus. Pattern-library SCSS only; deploys on the next rebuild.