### PR TITLE
style(footer): reduce the docs footer CTA (size(2) was too big)

### DIFF
--- a/pattern-library/source/sass/03-groups/05-footers/00-footer.scss
+++ b/pattern-library/source/sass/03-groups/05-footers/00-footer.scss
@@ -16,13 +16,10 @@
       @include make-link-docs();
     }
     // The docs footer is a call to action rather than fine print, so it is
-    // centred (text-align above) and set noticeably larger than the default
-    // copyright text, stepping up again on wider screens so the CTA stands out.
+    // centred (text-align above) and set one step larger than the default
+    // copyright text.
     .g-footer__message {
       font-size: size(1);
-      @include respond-to(md) {
-        font-size: size(2);
-      }
     }
   }
 }


### PR DESCRIPTION
Follow-up to #192. The size(2) bump on md+ (1.44rem) read as too big once live. Drop the responsive bump and keep size(1) (1.2rem) at all widths, still centred. Net: one modest step up from the copyright default. Pattern-library SCSS only; deploys on the next rebuild.