### PR TITLE
build(docs): remove unused CSS from docs-main.css with PurgeCSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ docs/tagfile
 # CI tooling deps (terser for minifying Doxygen JS); package-lock.json
 # is committed so `npm ci` in the build workflow is reproducible.
 ci/node_modules/
+
+# Build-time report from the PurgeCSS pass (ci/purge-docs-css.js); written
+# against generated output during the docs build, not a source artifact.
+ci/purge-docs-css.report.json

--- a/ci/generate-documentation.ps1
+++ b/ci/generate-documentation.ps1
@@ -194,16 +194,30 @@ Set-Content -Path $manifestPath -Value ($mirrored -join "`n")
 Write-Host "Mirrored $($mirrored.Count - $assetsCopied) HTML files and $assetsCopied image assets to gh-pages root, added canonical to $canonicalsAdded versioned files, added hreflang to $hreflangsAdded versioned files."
 Write-Host "::endgroup::"
 
-# Minify the Doxygen-emitted JS (jquery.js, navtree.js, dynsections.js,
-# search51.js, examplegrabber.js, testedversionsgrabber.js, ...) and
-# rewrite <script src="*.js"> in every generated page to load the
-# *.min.js sibling. Mirrors the docs-main.css / docs-main.min.css
-# convention already used for the stylesheet. Clears the Semrush rule
-# 135 ("unminified JavaScript and CSS files") findings on every
-# /documentation/* page on 51degrees.com.
-Write-Host "::group::Minifying Doxygen-emitted JS"
+# Remove unused CSS selectors from the design-system stylesheet, scanning
+# the HTML Doxygen actually generated for this version. docs-main.css is
+# the full 51Degrees design system, but a /documentation/* page uses only
+# the chrome subset (header/footer/search/sidenav defined in the doxygen
+# templates) plus whatever the body markup references, so this drops the
+# unused remainder (configurator, demo and marketing components). Mirrors
+# the website's PurgeCSS pass (Website/website/scripts/purge-css.js). Runs
+# before the minify step below so csso minifies the already-purged
+# docs-main.css into docs-main.min.css. npm ci here installs the tooling
+# (purgecss, terser, csso) once for both this step and the minify step.
+Write-Host "::group::Removing unused CSS from docs-main.css"
 Push-Location ci
 try { npm ci --omit=dev=false --no-audit --no-fund } finally { Pop-Location }
+node ci/purge-docs-css.js "gh-pages/$version"
+Write-Host "::endgroup::"
+
+# Minify the purged docs-main.css and the Doxygen-emitted JS (jquery.js,
+# navtree.js, dynsections.js, search51.js, examplegrabber.js,
+# testedversionsgrabber.js, ...), then rewrite <script src="*.js"> and
+# <link href="*.css"> in every generated page to load the *.min.* sibling.
+# Clears the Semrush rule 135 ("unminified JavaScript and CSS files")
+# findings on every /documentation/* page on 51degrees.com. node_modules is
+# already installed by the purge step above.
+Write-Host "::group::Minifying Doxygen-emitted JS and CSS"
 node ci/minify-docs-assets.js gh-pages
 Write-Host "::endgroup::"
 

--- a/ci/package-lock.json
+++ b/ci/package-lock.json
@@ -7,7 +7,17 @@
       "name": "ci-docs-tooling",
       "dependencies": {
         "csso": "^5.0.5",
+        "purgecss": "^7.0.2",
         "terser": "^5.31.6"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -67,6 +77,27 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -78,6 +109,20 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/css-tree": {
       "version": "2.2.1",
@@ -93,6 +138,18 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/csso": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
@@ -106,11 +163,258 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.0.28",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "license": "CC0-1.0"
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.3.tgz",
+      "integrity": "sha512-cDoO18VWCIWRsSaws3C23b0HXRxlUknttfdNcbXnf3IGHAPRNLlXPHc6dYiatOkxW0W4uZh524Plaaw5a7WEtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/purgecss": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-7.0.2.tgz",
+      "integrity": "sha512-4Ku8KoxNhOWi9X1XJ73XY5fv+I+hhTRedKpGs/2gaBKU8ijUiIKF/uyyIyh7Wo713bELSICF5/NswjcuOqYouQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.1.0",
+        "glob": "^11.0.0",
+        "postcss": "^8.4.47",
+        "postcss-selector-parser": "^6.1.2"
+      },
+      "bin": {
+        "purgecss": "bin/purgecss.js"
+      }
+    },
+    "node_modules/purgecss/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -156,6 +460,27 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     }
   }

--- a/ci/package.json
+++ b/ci/package.json
@@ -4,6 +4,7 @@
   "description": "Build-time tooling for the documentation pipeline (terser for Doxygen-emitted JS, csso for Doxygen-emitted CSS).",
   "dependencies": {
     "csso": "^5.0.5",
+    "purgecss": "^7.0.2",
     "terser": "^5.31.6"
   }
 }

--- a/ci/purge-docs-css.js
+++ b/ci/purge-docs-css.js
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// Remove unreferenced CSS selectors from the documentation design-system
+// stylesheet (docs-main.css) using PurgeCSS, scanning the HTML that
+// Doxygen has actually generated for this build.
+//
+// This mirrors the website's scripts/purge-css.js, adapted to the
+// documentation pipeline:
+//
+//   * The website's CSS and content (Razor pages) live in the same source
+//     tree, so it purges at publish time against the source. The
+//     documentation pages are *generated* by Doxygen, so the consuming
+//     HTML only exists after the docs build. This script therefore runs
+//     inside ci/generate-documentation.ps1, after Doxygen, against the
+//     generated tree (gh-pages/<version>).
+//
+//   * docs-main.css is the full 51Degrees design system. A doxygen page
+//     uses only the chrome subset (header/footer/search/sidenav defined
+//     in docs/header.html + docs/footer.html) plus whatever the body
+//     markup references. Everything else (configurator panels, demo
+//     widgets, marketing components, ...) is unused on /documentation/*
+//     and is what this removes.
+//
+//   * The generated *.js (doxygen's navtree/search and the 51Degrees
+//     behaviours) is scanned as content too, so class names a script adds
+//     at runtime are kept when they appear as string literals. A small
+//     standard safelist covers the state classes toggled purely in JS.
+//
+// Minification is left to the existing csso pass in minify-docs-assets.js,
+// which runs immediately after this and produces docs-main.min.css from
+// the purged docs-main.css. So the order is purge -> minify.
+//
+// Usage:
+//   node ci/purge-docs-css.js <generated-tree> [--report <path>]
+//
+// <generated-tree> is the directory to scan and whose docs-main.css
+// copies are purged in place (e.g. gh-pages/4.5).
+
+const fs = require('fs')
+const path = require('path')
+const zlib = require('zlib')
+const { PurgeCSS } = require('purgecss')
+
+function arg(name, defaultValue) {
+  const idx = process.argv.indexOf('--' + name)
+  if (idx >= 0 && process.argv[idx + 1]) return process.argv[idx + 1]
+  return defaultValue
+}
+
+const ROOT = process.argv[2]
+if (!ROOT) {
+  console.error('usage: node ci/purge-docs-css.js <generated-tree> [--report <path>]')
+  process.exit(2)
+}
+const rootStat = fs.existsSync(ROOT) ? fs.statSync(ROOT) : null
+if (!rootStat || !rootStat.isDirectory()) {
+  console.error(`purge-docs-css: "${ROOT}" is not a directory`)
+  process.exit(2)
+}
+const SCRIPT_DIR = __dirname
+const REPORT_PATH = path.resolve(arg('report', path.join(SCRIPT_DIR, 'purge-docs-css.report.json')))
+
+// Forward slashes for glob, scoped strictly to the version tree passed in
+// so sibling versions already published under gh-pages are left untouched.
+const GLOB_ROOT = path.resolve(ROOT).replace(/\\/g, '/')
+
+// Content the design-system classes can be referenced from. The HTML is
+// the source of truth (header/footer chrome is baked into every page).
+// The JS is scanned so a class a script attaches at runtime is kept when
+// it appears as a literal. At this stage the tree holds only the original
+// *.js / *.css (the .min.* siblings are produced by the later minify
+// pass), so no .min exclusion is needed.
+const contentGlobs = [
+  GLOB_ROOT + '/**/*.html',
+  GLOB_ROOT + '/**/*.js',
+]
+
+// Only the unminified design-system stylesheet. `docs-main.css` does not
+// match `docs-main.min.css`, and a version-scoped root means we never
+// touch other versions' copies.
+const cssGlobs = [GLOB_ROOT + '/**/docs-main.css']
+
+;(async () => {
+  const result = await new PurgeCSS().purge({
+    content: contentGlobs,
+    css: cssGlobs,
+    safelist: {
+      standard: [
+        // State classes toggled in JS that may not appear in any static
+        // HTML snapshot. No-ops if absent from the CSS, kept if present.
+        'active', 'open', 'show', 'hide', 'hidden',
+        'is-active', 'is-open', 'is-openable', 'is-visible', 'is-hidden',
+      ],
+      // Keep every is-/js- state-modifier the design system defines; these
+      // are added/removed at runtime by the 51Degrees behaviours (search,
+      // sidenav, accordions) and need not be present in a static page.
+      greedy: [/^is-/, /^js-/],
+    },
+    // Conservative: keep all custom properties, @keyframes and @font-face
+    // even when no scanned rule references them. Matches the website.
+    variables: false,
+    keyframes: false,
+    fontFace: false,
+  })
+
+  if (result.length === 0) {
+    console.error('purge-docs-css: no docs-main.css matched under ' + ROOT + '. Nothing purged.')
+    process.exit(1)
+  }
+
+  const classCount = (s) =>
+    new Set((s.match(/\.[a-z][\w-]*/gi) || []).map((x) => x.slice(1))).size
+
+  const report = {
+    root: GLOB_ROOT,
+    files: [],
+    totals: { beforeRaw: 0, afterRaw: 0, beforeGz: 0, afterGz: 0 },
+  }
+
+  for (const r of result) {
+    const file = r.file
+    if (!file || !fs.existsSync(file)) continue
+    const before = fs.readFileSync(file, 'utf8')
+    const purged = r.css
+    fs.writeFileSync(file, purged)
+
+    const beforeGz = zlib.gzipSync(before).length
+    const afterGz = zlib.gzipSync(purged).length
+    const rel = path.relative(GLOB_ROOT, file).replace(/\\/g, '/')
+    report.files.push({
+      file: rel,
+      bytes: { beforeRaw: before.length, afterRaw: purged.length, beforeGz, afterGz },
+      classes: { before: classCount(before), after: classCount(purged) },
+    })
+    report.totals.beforeRaw += before.length
+    report.totals.afterRaw += purged.length
+    report.totals.beforeGz += beforeGz
+    report.totals.afterGz += afterGz
+
+    const pct = (a, b) => (b > 0 ? ((1 - a / b) * 100).toFixed(1) : '0.0')
+    console.log(
+      'purge-docs-css: ' + rel + ': ' +
+      before.length + ' -> ' + purged.length + ' B raw (-' + pct(purged.length, before.length) + '%), ' +
+      beforeGz + ' -> ' + afterGz + ' B gz (-' + pct(afterGz, beforeGz) + '%)'
+    )
+  }
+
+  fs.mkdirSync(path.dirname(REPORT_PATH), { recursive: true })
+  fs.writeFileSync(REPORT_PATH, JSON.stringify(report, null, 2))
+})().catch((e) => {
+  console.error('purge-docs-css: failed:', e.message)
+  process.exit(1)
+})


### PR DESCRIPTION
Adds a PurgeCSS pass to the docs build so the served stylesheet only contains the classes the generated documentation HTML actually uses, mirroring the website's PurgeCSS approach (`Website/website/scripts/purge-css.js`).

## What

- New `ci/purge-docs-css.js` (PurgeCSS runner), wired into `ci/generate-documentation.ps1` **after** Doxygen generates the HTML and **before** the existing csso minify step. Purge -> minify, the same order the website uses.
- It scans the generated `*.html` + `*.js` under the version tree as content and purges every `docs-main.css` in place. The existing minify step then produces `docs-main.min.css` from the purged file.
- Safelist keeps runtime-toggled state classes (`is-*`, `js-*`, `active`/`open`/`show`/...). Scoped strictly to `gh-pages/$version`, so previously deployed version trees are untouched.
- `purgecss ^7.0.2` added to `ci/package.json` (matches the website). `npm audit`: still **0 vulnerabilities**.

## Why

`docs-main.css` is the full 51Degrees design system, but a `/documentation/*` page only uses the chrome subset (header, footer, search, sidenav) plus what the body markup references. The rest (configurator, demos, marketing components) was shipped unused on every doc page.

## Validation (local 4.5 tree, 205 pages)

- `docs-main.css`: **54,926 -> 22,130 B raw (-59.7%)**, **8,826 -> 4,870 B gzip (-44.8%)**.
- Of **517** distinct classes referenced across all generated HTML + JS, **zero styled-and-used classes were dropped**. All chrome classes survived.
- `npm ci` succeeds with the synced lockfile.