### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/.utm-lint.json
+++ b/.utm-lint.json
@@ -1,0 +1,3 @@
+{
+  "exclude": ["^src/", "^docs/", "^pattern-library/"]
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=readme_main "Data rewards the curious") **Pipeline API Documentation**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=documentation&utm_content=readme.md&utm_term=top "Data rewards the curious") **Pipeline API Documentation**
 
 # Summary
 


### PR DESCRIPTION
## Summary

Every navigational 51degrees.com and configure.51degrees.com link in this repository now carries the standard UTM query string so the Content Team can trace Matomo campaign traffic to the exact repository, file, and location it came from:

`?utm_source=<github|code|nuget|npm|maven|packagist>&utm_medium=<readme|docs|example|comment|package>&utm_campaign=<repository>&utm_content=<file slug>&utm_term=<location in file>`

1 links across 3 files, in-place URL replacements only. While tagging, http, www, and protocol-relative variants were normalised to https on the bare domain, pre-2026 utm schemes were replaced, and the retired Logo.ashx banner URL was replaced with img/logo.png where present. Functional endpoints (cloud, distributor, devices-v4, bulkdata), test fixtures, license headers, and generated files are untouched.

## Lint

A second commit adds the utm-link-lint workflow, which runs the shared script from 51Degrees/common-ci on pull requests and pushes to main, keeping the convention enforced from now on. An accompanying .utm-lint.json excludes src/, docs/, and pattern-library/, the published site content where links are internal by design. The lint check on this PR stays red until 51Degrees/common-ci#207 merges, since the workflow fetches the script from that repository's main.

The full convention is documented in UTM-LINK-TAGGING.md in 51Degrees/internal-common-ci (PR 3).