### PR TITLE
feat(pattern-library): Contact Us message variants for non-paid key/data file

### DIFF
--- a/pattern-library/source/_patterns/06-examples/08-message.twig
+++ b/pattern-library/source/_patterns/06-examples/08-message.twig
@@ -1,7 +1,14 @@
+{# Bottom-of-page message shown only when a non-paid resource key or data file
+   is in use. Two variants:
+   - cloud     (default) on the free-tier cloud examples, cross-sells on-premise
+   - onpremise on the Lite data file examples, points at more properties/features
+   Both link to the Contact Us page (inline link + button). #}
+{% set messageVariant = messageVariant|default('cloud') %}
 <div class="c-eg-message">
-  <p class="c-eg-message__text">
-    Only a limited set of properties is available with the free Lite data file or default
-    resource key. Access the full set of properties with a paid data file or resource key.
-  </p>
-  <a class="b-btn c-eg-message__cta" href="https://51degrees.com/pricing">Find out more</a>
+  {% if messageVariant == 'onpremise' %}
+  <p class="c-eg-message__text">Need more on-premise properties and features? <a href="https://51degrees.com/contact-us">Contact us</a> to explore the options.</p>
+  {% else %}
+  <p class="c-eg-message__text">Want to try on-premise? <a href="https://51degrees.com/contact-us">Contact us</a> to discuss requirements.</p>
+  {% endif %}
+  <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us">Contact us</a>
 </div>

--- a/pattern-library/source/_patterns/06-examples/08-message.twig
+++ b/pattern-library/source/_patterns/06-examples/08-message.twig
@@ -1,11 +1,15 @@
 {# Bottom-of-page message shown only when a non-paid resource key or data file
-   is in use. Two variants:
-   - cloud     (default) on the free-tier cloud examples, cross-sells on-premise
-   - onpremise on the Lite data file examples, points at more properties/features
-   Both link to the Contact Us page (inline link + button). #}
+   is in use. Variants:
+   - cloud        (default) free-tier cloud examples, cross-sells on-premise
+   - onpremise    Lite data file examples, points at more properties/features
+   - onpremise-dd Lite data file device-detection examples, lists the paid
+                  data file benefits (daily updates, non-human ID, IP intelligence)
+   All link to the Contact Us page (inline link + button). #}
 {% set messageVariant = messageVariant|default('cloud') %}
 <div class="c-eg-message">
-  {% if messageVariant == 'onpremise' %}
+  {% if messageVariant == 'onpremise-dd' %}
+  <p class="c-eg-message__text">The paid data file adds daily automatic updates, non-human identification and IP intelligence. <a href="https://51degrees.com/contact-us">Contact us</a> to explore the options.</p>
+  {% elseif messageVariant == 'onpremise' %}
   <p class="c-eg-message__text">Need more on-premise properties and features? <a href="https://51degrees.com/contact-us">Contact us</a> to explore the options.</p>
   {% else %}
   <p class="c-eg-message__text">Want to try on-premise? <a href="https://51degrees.com/contact-us">Contact us</a> to discuss requirements.</p>

--- a/pattern-library/source/_patterns/06-examples/README.md
+++ b/pattern-library/source/_patterns/06-examples/README.md
@@ -51,7 +51,7 @@ contract below.
 | map `#map-section` / `#map` | `.c-eg-map` / `.c-eg-map__canvas` |
 | two-column results (mixed) | `.c-eg-columns` |
 | collapsible evidence | `.c-eg-details` (native `<details>`) |
-| bottom-of-page message | `.c-eg-message` / `.c-eg-message__text` / `.c-eg-message__cta` |
+| bottom-of-page message | `.c-eg-message` / `.c-eg-message__text` / `.c-eg-message__cta` (see [Message variants](#message-variants)) |
 
 ## Pages (one per web example type)
 
@@ -63,9 +63,47 @@ Composed pages in `Examples/Pages` show how a full example app renders:
 - `ip-getting-started` — IP lookup form, results, evidence, headers, location map.
 - `ip-mixed` — two-column device + IP results with a collapsible evidence panel.
 
-Every page ends with the `.c-eg-message` banner, rendered when the view sets `showMessage`
-to true (free Lite data file or default resource key). In a real example app, drive the
-flag from the data tier or resource key, for example `ShowMessage = engine.DataSourceTier == "Lite"`.
+Every page ends with the `.c-eg-message` banner, rendered only when a non-paid
+resource key or data file is in use. See [Message variants](#message-variants) below.
+
+## Message variants
+
+The banner has two copy variants, both linking to the Contact Us page
+(`https://51degrees.com/contact-us`) from an inline text link and a button. Show
+the banner **only** when a non-paid resource key or data file is in use.
+
+**Cloud (free-tier cloud examples — getting-started, client-only, client-hints, mixed).**
+Cross-sells on-premise. The paid-only cloud examples (TAC lookup, native model) do
+**not** show it.
+
+```html
+<div class="c-eg-message">
+  <p class="c-eg-message__text">Want to try on-premise? <a href="https://51degrees.com/contact-us">Contact us</a> to discuss requirements.</p>
+  <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us">Contact us</a>
+</div>
+```
+
+**On-premise (Lite data file).** Shown when the engine reports the Lite data tier.
+
+```html
+<div class="c-eg-message">
+  <p class="c-eg-message__text">Need more on-premise properties and features? <a href="https://51degrees.com/contact-us">Contact us</a> to explore the options.</p>
+  <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us">Contact us</a>
+</div>
+```
+
+Drive the flag from the engine, per SDK:
+
+| SDK | On-premise Lite check | Cloud free-tier examples |
+|-----|----------------------|--------------------------|
+| .NET | `engine.DataSourceTier == "Lite"` | show (getting-started / client-only / client-hints / mixed) |
+| Java | `engine.getDataSourceTier().equals("Lite")` | show |
+| Node | `engine.getProduct() === "Lite"` | show |
+| PHP | `$engine->engine->getProduct() === "Lite"` | show |
+| Python | `engine.engine.getProduct() == "Lite"` | show |
+
+There is no cloud "free vs paid" API, so the cloud banner is shown on the
+free-by-design cloud examples and omitted from the paid-only ones.
 
 ## JavaScript (`fodExamples`)
 

--- a/pattern-library/source/_patterns/06-examples/README.md
+++ b/pattern-library/source/_patterns/06-examples/README.md
@@ -68,7 +68,7 @@ resource key or data file is in use. See [Message variants](#message-variants) b
 
 ## Message variants
 
-The banner has two copy variants, both linking to the Contact Us page
+The banner has three copy variants, all linking to the Contact Us page
 (`https://51degrees.com/contact-us`) from an inline text link and a button. Show
 the banner **only** when a non-paid resource key or data file is in use.
 
@@ -83,11 +83,20 @@ Cross-sells on-premise. The paid-only cloud examples (TAC lookup, native model) 
 </div>
 ```
 
-**On-premise (Lite data file).** Shown when the engine reports the Lite data tier.
+**On-premise (Lite data file).** Shown when the engine reports the Lite data tier. Generic wording used by the IP intelligence examples.
 
 ```html
 <div class="c-eg-message">
   <p class="c-eg-message__text">Need more on-premise properties and features? <a href="https://51degrees.com/contact-us">Contact us</a> to explore the options.</p>
+  <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us">Contact us</a>
+</div>
+```
+
+**On-premise device detection (Lite data file).** Same Lite trigger, but the device-detection examples list the paid data file benefits.
+
+```html
+<div class="c-eg-message">
+  <p class="c-eg-message__text">The paid data file adds daily automatic updates, non-human identification and IP intelligence. <a href="https://51degrees.com/contact-us">Contact us</a> to explore the options.</p>
   <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us">Contact us</a>
 </div>
 ```
@@ -104,6 +113,15 @@ Drive the flag from the engine, per SDK:
 
 There is no cloud "free vs paid" API, so the cloud banner is shown on the
 free-by-design cloud examples and omitted from the paid-only ones.
+
+## Data-file-age warning
+
+Separate from the upgrade banner, the on-premise examples show a stale-data-file
+warning (a `.c-eg-alert`) when the loaded data file is older than the age
+threshold. This is a distinct message from the upgrade banner and must remain. It
+renders as a warning at the **top of the page** — the first child inside
+`.c-eg-page`, before the page title — so it is seen before the (possibly stale)
+results below it.
 
 ## JavaScript (`fodExamples`)
 

--- a/pattern-library/source/sass/06-examples/06-message.scss
+++ b/pattern-library/source/sass/06-examples/06-message.scss
@@ -1,8 +1,9 @@
 /**
- * Bottom-of-page message. Mainly used to point the user at how to access the
- * full set of properties when running on the free Lite data file or a default
- * resource key. Neutral banner so the lime call-to-action stands out. Toggled
- * per page by the `showMessage` flag in the view.
+ * Bottom-of-page message, shown only when a non-paid resource key or data file
+ * is in use. Two copy variants (cloud free-tier vs Lite data file), both with an
+ * inline Contact Us link and a Contact Us button. Neutral banner so the lime
+ * call-to-action stands out. Toggled per page by the `showMessage` flag in the
+ * view; the wording is chosen by the `messageVariant` flag.
  */
 
 .c-eg-message {

--- a/pattern-library/stories/ExamplePages.stories.js
+++ b/pattern-library/stories/ExamplePages.stories.js
@@ -19,9 +19,13 @@ IpMixed.storyName = "ip intelligence - mixed (device + ip)";
 export const DdGettingStartedCloudMessage = () => renderPattern("examples-dd-getting-started", { messageVariant: "cloud" });
 DdGettingStartedCloudMessage.storyName = "message - cloud free tier (try on-premise)";
 
-// On-premise Lite message (more properties/features) — shown on the Lite data file examples.
+// On-premise Lite message (more properties/features) — generic, used by the IP examples.
 export const IpGettingStartedOnPremMessage = () => renderPattern("examples-ip-getting-started", { messageVariant: "onpremise" });
 IpGettingStartedOnPremMessage.storyName = "message - on-premise Lite (more properties)";
+
+// On-premise Lite message listing the paid data file benefits — used by the device detection examples.
+export const DdGettingStartedOnPremMessage = () => renderPattern("examples-dd-getting-started", { messageVariant: "onpremise-dd" });
+DdGettingStartedOnPremMessage.storyName = "message - on-premise device detection (paid benefits)";
 
 // Same page with the message toggled off (paid data file / full resource key).
 export const DdGettingStartedPaid = () => renderPattern("examples-dd-getting-started", { showMessage: false });

--- a/pattern-library/stories/ExamplePages.stories.js
+++ b/pattern-library/stories/ExamplePages.stories.js
@@ -15,6 +15,14 @@ IpGettingStarted.storyName = "ip intelligence - getting started";
 export const IpMixed = () => renderPattern("examples-ip-mixed");
 IpMixed.storyName = "ip intelligence - mixed (device + ip)";
 
+// Cloud free-tier message (cross-sells on-premise) — shown on the cloud examples.
+export const DdGettingStartedCloudMessage = () => renderPattern("examples-dd-getting-started", { messageVariant: "cloud" });
+DdGettingStartedCloudMessage.storyName = "message - cloud free tier (try on-premise)";
+
+// On-premise Lite message (more properties/features) — shown on the Lite data file examples.
+export const IpGettingStartedOnPremMessage = () => renderPattern("examples-ip-getting-started", { messageVariant: "onpremise" });
+IpGettingStartedOnPremMessage.storyName = "message - on-premise Lite (more properties)";
+
 // Same page with the message toggled off (paid data file / full resource key).
 export const DdGettingStartedPaid = () => renderPattern("examples-dd-getting-started", { showMessage: false });
 DdGettingStartedPaid.storyName = "device detection - getting started (paid, no message)";

--- a/pattern-library/stories/render-twig.js
+++ b/pattern-library/stories/render-twig.js
@@ -91,6 +91,9 @@ export function renderPattern(rawId, extra = {}) {
     // Example pages show the message by default (free Lite data file / default
     // resource key). Stories pass showMessage:false for the paid case.
     showMessage: true,
+    // Message variant: 'cloud' (free-tier cloud, cross-sell on-premise) or
+    // 'onpremise' (Lite data file, more properties/features). Stories override.
+    messageVariant: 'cloud',
   };
   const data = { ...baseline, ...(dataById[id] || {}), ...extra };
   try {


### PR DESCRIPTION
## Contact Us message variants for the examples message component

Follow-up to #208. Extends the bottom-of-page examples message (`.c-eg-message`) so it is shown **only when a non-paid resource key or data file is in use**, with two copy variants that both link to the Contact Us page (inline text link + button):

- **Cloud (free-tier cloud examples):** "Want to try on-premise? Contact us to discuss requirements." Shown on the free-by-design cloud examples (getting-started, client-only, client-hints, mixed); omitted from the paid-only cloud examples (TAC lookup, native model).
- **On-premise (Lite data file):** "Need more on-premise properties and features? Contact us to explore the options." Shown when the engine reports the Lite data tier.

### Why two variants
There is no cloud "free vs paid" API, so the cloud banner is shown on the free-by-design cloud examples and omitted from the paid-only ones. On-premise is driven directly from the data tier.

### Changes
- `08-message.twig` branches on a `messageVariant` flag (`cloud` default, `onpremise`), both pointing at `https://51degrees.com/contact-us`.
- `render-twig.js` adds the `messageVariant` baseline; `ExamplePages.stories.js` shows both variants in Storybook.
- `06-message.scss` comment updated (no style change).
- `README.md` documents both markup blocks and the per-SDK trigger.

No change to the consumable CSS/JS assets, so no new `examples-assets-*` release is required. The rollout repos vendor the markup directly per the README contract.
