### PR TITLE
Add the Rust tab to the tested-versions page

### DIFF
--- a/src/productsummaries/testedversions.md
+++ b/src/productsummaries/testedversions.md
@@ -162,14 +162,15 @@ These are tested on [GitHub](https://github.com/51Degrees?q=rust&type=all&langua
 
 Platforms:
 - Windows (windows-latest, x86_64)
-- Linux (ubuntu-latest, x86_64)
+- Linux (ubuntu-22.04 and ubuntu-24.04, x86_64)
+- macOS (macos-latest, Apple Silicon / arm64)
 
 Language Versions:
 - Rust stable (current)
 - Minimum supported Rust version: 1.94
 
 Targets:
-- Native (x86_64)
+- Native (x86_64 and Apple Silicon arm64)
 - wasm32-wasip1 (the cloud and web crates, for edge runtimes such as Fastly Compute)
 
 If you have a configuration that is not covered, please [contact us](https://51degrees.com/contact-us).

--- a/src/productsummaries/testedversions.md
+++ b/src/productsummaries/testedversions.md
@@ -158,8 +158,20 @@ Platforms:
 
 @endsnippet
 @startsnippet{rust}
+These are tested on [GitHub](https://github.com/51Degrees?q=rust&type=all&language=&sort=).
 
-Not tested by 51Degrees.
+Platforms:
+- Windows (windows-latest, x86_64)
+- Linux (ubuntu-latest, x86_64)
 
+Language Versions:
+- Rust stable (current)
+- Minimum supported Rust version: 1.94
+
+Targets:
+- Native (x86_64)
+- wasm32-wasip1 (the cloud and web crates, for edge runtimes such as Fastly Compute)
+
+If you have a configuration that is not covered, please [contact us](https://51degrees.com/contact-us).
 @endsnippet
 @endsnippets


### PR DESCRIPTION
Fills in the previously empty Rust entry on the product tested-versions page.

Content:
- Platforms: Windows (windows-latest) and Linux (ubuntu-latest), x86_64.
- Language versions: Rust stable plus the minimum supported Rust version (1.94).
- Targets: native (x86_64) and wasm32-wasip1 for the cloud and web crates (edge runtimes such as Fastly Compute).
- GitHub testing link and contact-us link, matching the format of the other language tabs.

The links follow the same convention as the sibling snippets (no UTM tags, as required for published documentation content).