### PR TITLE
Add vertical spacing around c-code__block

### DIFF
--- a/pattern-library/source/sass/02-components/03-main/06-code.scss
+++ b/pattern-library/source/sass/02-components/03-main/06-code.scss
@@ -46,6 +46,9 @@
   text-align: left;
   background-color:$colour-white;
   padding: size(0);
+  // Vertical breathing room so code blocks are clearly separated from the
+  // surrounding prose, above and below.
+  margin: size(0) 0;
   border-radius:$rounded;
   display:block;
   overflow: scroll;


### PR DESCRIPTION
Code blocks (`.c-code__block`) had padding but no outer margin, so they sat flush against the surrounding prose. Adds a base-unit (`size(0)`) top and bottom margin for clear separation above and below.

Edit is in the SCSS source (`pattern-library/source/sass/02-components/03-main/06-code.scss`); the compiled `docs-main.css` is regenerated from it by `ci/build-pattern-library.ps1` during the build.

(Base is `main`; happy to retarget to `release/20260619a` if this should ship with that release.)