### PR TITLE
doc: add Self-Hosted Docker page under Services > Cloud

### DIFF
--- a/src/services/cloud/index.md
+++ b/src/services/cloud/index.md
@@ -2,6 +2,8 @@
 
 - @subpage Services_Cloud_Overview
 
+- @subpage Services_Cloud_SelfHostedDocker
+
 - @subpage Services_Cloud_ResourceKeys
 
 - @subpage Services_Cloud_ErrorMessages

--- a/src/services/cloud/overview.md
+++ b/src/services/cloud/overview.md
@@ -1,6 +1,6 @@
 @page Services_Cloud_Overview Cloud Service Overview
 
-There are a couple methods to integrate the Cloud Service, but regardless of the integration method you will need a [Resource Key](@ref Services_Cloud_ResourceKeys).
+There are a couple methods to integrate the Cloud Service, but regardless of the integration method you will need a [Resource Key](@ref Services_Cloud_ResourceKeys). The exception is the [Self-Hosted Docker](@ref Services_Cloud_SelfHostedDocker) image, which you run on your own infrastructure and authorize with a License Key instead.
 
 ---
 

--- a/src/services/cloud/overview.md
+++ b/src/services/cloud/overview.md
@@ -2,7 +2,7 @@
 
 There are a couple methods to integrate the Cloud Service, but regardless of the integration method you will need a credential: a [Resource Key](@ref Services_Cloud_ResourceKeys), or, on the json and js endpoints, a License Key for callers that manage their own property list.
 
-This page describes the hosted Cloud Service. The [Self-Hosted Docker](@ref Services_Cloud_SelfHostedDocker) image serves the same API from your own infrastructure and uses no Resource Keys at all: every request is authorized by the License Key(s) the container is started with.
+The [Self-Hosted Docker](@ref Services_Cloud_SelfHostedDocker) image serves the same API from your own infrastructure. It takes the same License Key, supplied once when the container starts rather than per request, and uses no Resource Keys.
 
 ---
 

--- a/src/services/cloud/overview.md
+++ b/src/services/cloud/overview.md
@@ -1,8 +1,8 @@
 @page Services_Cloud_Overview Cloud Service Overview
 
-There are a couple methods to integrate the Cloud Service, but regardless of the integration method you will need a credential: a [Resource Key](@ref Services_Cloud_ResourceKeys), or, on the json and js endpoints, a License Key for callers that manage their own property list.
+The Cloud Service comes in two forms: the Cloud hosted by 51Degrees, which this page describes, and the [Self-Hosted Docker](@ref Services_Cloud_SelfHostedDocker) image, which serves the same API from your own infrastructure and authenticates with your License Key alone, supplied once when the container starts.
 
-The [Self-Hosted Docker](@ref Services_Cloud_SelfHostedDocker) image serves the same API from your own infrastructure. It takes the same License Key, supplied once when the container starts rather than per request, and uses no Resource Keys.
+There are a couple methods to integrate the hosted Cloud Service, but regardless of the integration method you will need a credential: a [Resource Key](@ref Services_Cloud_ResourceKeys), or, on the json and js endpoints, a License Key for callers that manage their own property list.
 
 ---
 

--- a/src/services/cloud/selfhosteddocker.md
+++ b/src/services/cloud/selfhosteddocker.md
@@ -1,19 +1,22 @@
 @page Services_Cloud_SelfHostedDocker Self-Hosted Docker
 
-The 51Degrees Private Cloud is a self-hosted Docker container that runs the
-51Degrees Cloud API entirely on your own infrastructure. It is **single-tenant**:
-every request is authorized by the License Key(s) you start the container with.
-There are no resource keys, and the container makes **no outbound calls** to
-51Degrees services - no usage sharing and no entitlement/billing lookups.
+The Self-Hosted Cloud Docker image runs the
+[51Degrees Cloud Service](@ref Services_Cloud_Overview) API entirely on your own
+infrastructure. It is **single-tenant**: every request is authorized by the
+License Key(s) you start the container with. There are no
+[resource keys](@ref Services_Cloud_ResourceKeys), and the container makes
+**no outbound calls** to 51Degrees services - no usage sharing and no
+entitlement/billing lookups.
 
 For the API itself (endpoints, evidence, response format), see the interactive
 documentation served by the running container at `/api-docs`.
 
 # Prerequisites
 
-- A container runtime (Docker, Podman, Kubernetes, …).
-- The `51degrees/cloud-private` container image, supplied by 51Degrees. The
-  image already contains the data files it needs (see Data Files below).
+- A container runtime (Docker, Podman, Kubernetes, etc.).
+- The `51degrees/cloud-private` container image. The image is distributed
+  privately: [contact us](https://51degrees.com/contact-us) to be granted access
+  to it. It already contains the data files it needs (see Data Files below).
 - One or more 51Degrees **License Keys** that entitle the products you need.
 
 # Data Files
@@ -21,8 +24,8 @@ documentation served by the running container at `/api-docs`.
 The data files are baked into the `51degrees/cloud-private` image at
 `/app/data/assets`, so you do not need to supply or mount anything:
 
-- `TAC-HashV41.hash` - Device Detection
-- `51Degrees-EnterpriseIpiV41.ipi` - IP Intelligence
+- `TAC-HashV41.hash` - @DeviceDetection
+- `51Degrees-EnterpriseIpiV41.ipi` - @IpIntelligence
 
 51Degrees ships a new image daily, with refreshed data files as needed, and
 each image is tagged with its build date. To move to newer data, pull a newer
@@ -33,14 +36,14 @@ image (see Updating).
 | Variable | Required | Description |
 | -------- | -------- | ----------- |
 | `LICENSE_KEYS` | **yes** | One or more 51Degrees License Keys (comma-separated). Determines the products and properties the container serves. |
-| `PROPERTIES_DEVICE_DETECTION` | no | Comma-separated list of Device Detection properties to expose. Empty (default) = all properties entitled by the license. |
-| `PROPERTIES_IP_INTELLIGENCE` | no | Comma-separated list of IP Intelligence properties to expose. Empty (default) = all entitled. |
+| `PROPERTIES_DEVICE_DETECTION` | no | Comma-separated list of @devicedetection properties to expose. Empty (default) = all properties entitled by the license. |
+| `PROPERTIES_IP_INTELLIGENCE` | no | Comma-separated list of @ipintelligence properties to expose. Empty (default) = all entitled. |
 | `PROPERTIES` | no | Fully-qualified `aspect.property` allow-list (and default) for the per-request `values` selector. Requires the `CloudV5Bespoke` product on the license. |
 | `DISABLED_ELEMENTS` | no | Comma-separated list of pipeline elements to remove, e.g. `TacEngine,NativeEngine,RobotsTxtEngineBuilder`. |
-| `IPI_CONCURRENCY` | no | Number of concurrent handles in the IP Intelligence engine pool (an unsigned integer). Raise this when peak request rates trigger "Insufficient handles available in the pool" errors. Default = `128`. Invalid or zero values fall back to the default. |
+| `IPI_CONCURRENCY` | no | Number of concurrent handles in the @ipintelligence engine pool (an unsigned integer). Raise this when peak request rates trigger "Insufficient handles available in the pool" errors. Default = `128`. Invalid or zero values fall back to the default. |
 | `REGION_NAME` | no | Free-text region label returned in the `51D-Region` response header and from `/api/info`. |
 | `ASPNETCORE_URLS` | no | Override the in-container listen address/port (the image listens on `8080` by default). |
-| `PipelineOptions__Elements__DidOnPremiseEngineBuilder__BuildParameters__IdDomain` | no | The domain embedded and cryptographically signed into every generated 51Did. Defaults to `51d.es`. Override only if your 51Dids must be attributed to a different domain. |
+| `PipelineOptions__Elements__DidOnPremiseEngineBuilder__BuildParameters__IdDomain` | no | The domain embedded and cryptographically signed into every generated [51Did](@ref Identifiers_51Did). Defaults to `51d.es`. Override only if your 51Dids must be attributed to a different domain. |
 | `PipelineOptions__Elements__CloudJavaScriptBuilderElement__BuildParameters__Host` | no | The host the generated client-side JavaScript calls back to. Default (unset) = the host the request arrived on (the forwarded `Host` header). Override only to force callbacks to a fixed host. |
 
 > **Note on the 51Did signing domain:** every 51Did the container generates is
@@ -67,7 +70,7 @@ image (see Updating).
 
 # Running
 
-```bash
+```{bash}
 docker run -d --name 51d-cloud \
   -p 8080:8080 \
   -e LICENSE_KEYS=<your-license-key> \
@@ -80,7 +83,7 @@ JavaScript callback host is derived from it (see the note above).
 
 # Verifying
 
-```bash
+```{bash}
 # Service version
 curl http://localhost:8080/api/info/version
 

--- a/src/services/cloud/selfhosteddocker.md
+++ b/src/services/cloud/selfhosteddocker.md
@@ -37,6 +37,7 @@ image (see Updating).
 | `PROPERTIES_IP_INTELLIGENCE` | no | Comma-separated list of IP Intelligence properties to expose. Empty (default) = all entitled. |
 | `PROPERTIES` | no | Fully-qualified `aspect.property` allow-list (and default) for the per-request `values` selector. Requires the `CloudV5Bespoke` product on the license. |
 | `DISABLED_ELEMENTS` | no | Comma-separated list of pipeline elements to remove, e.g. `TacEngine,NativeEngine,RobotsTxtEngineBuilder`. |
+| `IPI_CONCURRENCY` | no | Number of concurrent handles in the IP Intelligence engine pool (an unsigned integer). Raise this when peak request rates trigger "Insufficient handles available in the pool" errors. Default = `128`. Invalid or zero values fall back to the default. |
 | `REGION_NAME` | no | Free-text region label returned in the `51D-Region` response header and from `/api/info`. |
 | `ASPNETCORE_URLS` | no | Override the in-container listen address/port (the image listens on `8080` by default). |
 | `PipelineOptions__Elements__DidOnPremiseEngineBuilder__BuildParameters__IdDomain` | no | The domain embedded and cryptographically signed into every generated 51Did. Defaults to `51d.es`. Override only if your 51Dids must be attributed to a different domain. |

--- a/src/services/cloud/selfhosteddocker.md
+++ b/src/services/cloud/selfhosteddocker.md
@@ -1,0 +1,103 @@
+@page Services_Cloud_SelfHostedDocker Self-Hosted Docker
+
+The 51Degrees Private Cloud is a self-hosted Docker container that runs the
+51Degrees Cloud API entirely on your own infrastructure. It is **single-tenant**:
+every request is authorized by the License Key(s) you start the container with.
+There are no resource keys, and the container makes **no outbound calls** to
+51Degrees services - no usage sharing and no entitlement/billing lookups.
+
+For the API itself (endpoints, evidence, response format), see the interactive
+documentation served by the running container at `/api-docs`.
+
+# Prerequisites
+
+- A container runtime (Docker, Podman, Kubernetes, …).
+- The `51degrees/cloud-private` container image, supplied by 51Degrees.
+- One or more 51Degrees **License Keys** that entitle the products you need.
+- The data file(s) for the products you use, supplied by 51Degrees:
+  - `TAC-HashV41.hash` - Device Detection
+  - `51Degrees-EnterpriseIpiV41.ipi` - IP Intelligence
+
+# Data Files
+
+The container reads its data files from `/app/data/assets`. Mount a host
+directory containing the files there:
+
+```
+/your/data/dir/
+├── TAC-HashV41.hash
+└── 51Degrees-EnterpriseIpiV41.ipi
+```
+
+Data files are not baked into the image - mounting them means you can update
+data without rebuilding. To refresh, replace the files and restart the container.
+
+# Environment Variables
+
+| Variable | Required | Description |
+| -------- | -------- | ----------- |
+| `LICENSE_KEYS` | **yes** | One or more 51Degrees License Keys (comma-separated). Determines the products and properties the container serves. |
+| `PROPERTIES_DEVICE_DETECTION` | no | Comma-separated list of Device Detection properties to expose. Empty (default) = all properties entitled by the license. |
+| `PROPERTIES_IP_INTELLIGENCE` | no | Comma-separated list of IP Intelligence properties to expose. Empty (default) = all entitled. |
+| `PROPERTIES` | no | Fully-qualified `aspect.property` allow-list (and default) for the per-request `values` selector. Requires the `CloudV5Bespoke` product on the license. |
+| `DISABLED_ELEMENTS` | no | Comma-separated list of pipeline elements to remove, e.g. `TacEngine,NativeEngine,RobotsTxtEngineBuilder`. |
+| `REGION_NAME` | no | Free-text region label returned in the `51D-Region` response header and from `/api/info`. |
+| `ASPNETCORE_URLS` | no | Override the in-container listen address/port (the image listens on `8080` by default). |
+| `PipelineOptions__Elements__DidOnPremiseEngineBuilder__BuildParameters__IdDomain` | no | The domain embedded and cryptographically signed into every generated 51Did. Defaults to `51d.es`. Override only if your 51Dids must be attributed to a different domain. |
+| `PipelineOptions__Elements__CloudJavaScriptBuilderElement__BuildParameters__Host` | no | The host the generated client-side JavaScript calls back to. Default (unset) = the host the request arrived on (the forwarded `Host` header). Override only to force callbacks to a fixed host. |
+
+> **Note on the 51Did signing domain:** every 51Did the container generates is
+> stamped with, and signed under, a fixed domain (`51d.es` by default). This is a
+> trust anchor established at startup, **not** the host your end users reach the
+> container at - that is taken automatically from the request, so it needs no
+> configuration. Override the domain only via the
+> `PipelineOptions__Elements__DidOnPremiseEngineBuilder__BuildParameters__IdDomain`
+> environment variable above.
+
+> **Note on the JavaScript callback host:** the client-side JavaScript bundle
+> refetches data from this container, and by default targets the host the
+> original request arrived on (the `Host` header your reverse proxy forwards), so
+> no configuration is needed as long as the proxy preserves that header. If you
+> need callbacks to go to a fixed host instead, set it via the
+> `PipelineOptions__Elements__CloudJavaScriptBuilderElement__BuildParameters__Host`
+> environment variable above.
+
+> **Note on restricting properties:** if you set `PROPERTIES_DEVICE_DETECTION`,
+> keep the properties that other engines consume as input or the container will
+> fail to start: `deviceid`, `TAC`, `NativeModel` (required by the 51Did engine)
+> and `CrawlerName`, `CrawlerProductTokens`, `CrawlerUrl`, `CrawlerUsage`
+> (required by the robots.txt engine), in addition to whatever you want to expose.
+
+# Running
+
+```bash
+docker run -d --name 51d-cloud \
+  -p 8080:8080 \
+  -v /your/data/dir:/app/data/assets:ro \
+  -e LICENSE_KEYS=<your-license-key> \
+  51degrees/cloud-private
+```
+
+The container listens on port `8080`. Run it behind your own reverse proxy / TLS
+terminator, and make sure the proxy preserves the `Host` header - the client-side
+JavaScript callback host is derived from it (see the note above).
+
+# Verifying
+
+```bash
+# Service version
+curl http://localhost:8080/api/info/version
+
+# Properties available from your license
+curl http://localhost:8080/api/v4/accessibleproperties
+
+# Device detection + IP intelligence
+curl "http://localhost:8080/api/v4/json?user-agent=Mozilla/5.0%20(iPhone)&client-ip=2.125.160.216"
+```
+
+Interactive API documentation is served at `http://localhost:8080/api-docs`.
+
+# Updating
+
+- **Data files** - replace the files in your mounted data directory and restart the container.
+- **Software** - pull a newer `51degrees/cloud-private` image and recreate the container.

--- a/src/services/cloud/selfhosteddocker.md
+++ b/src/services/cloud/selfhosteddocker.md
@@ -12,25 +12,21 @@ documentation served by the running container at `/api-docs`.
 # Prerequisites
 
 - A container runtime (Docker, Podman, Kubernetes, …).
-- The `51degrees/cloud-private` container image, supplied by 51Degrees.
+- The `51degrees/cloud-private` container image, supplied by 51Degrees. The
+  image already contains the data files it needs (see Data Files below).
 - One or more 51Degrees **License Keys** that entitle the products you need.
-- The data file(s) for the products you use, supplied by 51Degrees:
-  - `TAC-HashV41.hash` - Device Detection
-  - `51Degrees-EnterpriseIpiV41.ipi` - IP Intelligence
 
 # Data Files
 
-The container reads its data files from `/app/data/assets`. Mount a host
-directory containing the files there:
+The data files are baked into the `51degrees/cloud-private` image at
+`/app/data/assets`, so you do not need to supply or mount anything:
 
-```
-/your/data/dir/
-├── TAC-HashV41.hash
-└── 51Degrees-EnterpriseIpiV41.ipi
-```
+- `TAC-HashV41.hash` - Device Detection
+- `51Degrees-EnterpriseIpiV41.ipi` - IP Intelligence
 
-Data files are not baked into the image - mounting them means you can update
-data without rebuilding. To refresh, replace the files and restart the container.
+51Degrees ships a new image daily, with refreshed data files as needed, and
+each image is tagged with its build date. To move to newer data, pull a newer
+image (see Updating).
 
 # Environment Variables
 
@@ -73,7 +69,6 @@ data without rebuilding. To refresh, replace the files and restart the container
 ```bash
 docker run -d --name 51d-cloud \
   -p 8080:8080 \
-  -v /your/data/dir:/app/data/assets:ro \
   -e LICENSE_KEYS=<your-license-key> \
   51degrees/cloud-private
 ```
@@ -99,5 +94,10 @@ Interactive API documentation is served at `http://localhost:8080/api-docs`.
 
 # Updating
 
-- **Data files** - replace the files in your mounted data directory and restart the container.
+Both the software and the data files ship inside the image, so updating either
+means moving to a newer image:
+
+- **Data files** - 51Degrees publishes a new `cloud-private` image daily, with
+  refreshed data files as needed. Pull the latest (date-tagged) image and
+  recreate the container to pick up newer data.
 - **Software** - pull a newer `51degrees/cloud-private` image and recreate the container.


### PR DESCRIPTION
Ports the Private Cloud deployment guide from [`51Degrees/cloud/PRIVATE_CLOUD_DEPLOYMENT_GUIDE.md`](https://github.com/51Degrees/cloud/blob/main/PRIVATE_CLOUD_DEPLOYMENT_GUIDE.md) into the public documentation.

## Changes
- New page `src/services/cloud/selfhosteddocker.md` (`@page Services_Cloud_SelfHostedDocker Self-Hosted Docker`) describing the self-hosted Docker deployment of the 51Degrees Cloud API.
- Registered it as a subpage in `src/services/cloud/index.md`, placed under **Services > Cloud** between Overview and Resource Keys.

Content matches the source guide with em-dashes replaced by hyphens.