### PR TITLE
DOC: link device detection comparison example

### DIFF
--- a/src/devicedetection/migrationguides/deviceatlas.md
+++ b/src/devicedetection/migrationguides/deviceatlas.md
@@ -5,6 +5,8 @@
 Here you'll find a list of DeviceAtlas properties and their 51Degrees equivalent. 
 Details of all available DeviceAtlas properties can be found on their website, whilst the [51Degrees property dictionary](https://51degrees.com/developers/property-dictionary) contains details of all our properties and their possible values.
 
+To see DeviceAtlas and 51Degrees detection running side by side, take a look at the [device detection comparison example](https://github.com/51Degrees/device-detection-java-examples/tree/main/console/src/main/java/fiftyone/devicedetection/examples/console/comparison) in our Java examples repository. It shows how the same User-Agent is processed by each provider, which makes the property equivalencies in the table below easier to follow.
+
 
 # Obsolete DeviceAtlas capabilities
 

--- a/src/devicedetection/migrationguides/deviceatlas.md
+++ b/src/devicedetection/migrationguides/deviceatlas.md
@@ -5,7 +5,7 @@
 Here you'll find a list of DeviceAtlas properties and their 51Degrees equivalent. 
 Details of all available DeviceAtlas properties can be found on their website, whilst the [51Degrees property dictionary](https://51degrees.com/developers/property-dictionary) contains details of all our properties and their possible values.
 
-To see DeviceAtlas and 51Degrees detection running side by side, take a look at the [device detection comparison example](https://github.com/51Degrees/device-detection-java-examples/blob/main/console/src/main/java/fiftyone/devicedetection/examples/console/comparison/Comparer.java) in our Java examples repository. It shows how the same User-Agent is processed by each provider, which makes the property equivalencies in the table below easier to follow.
+To see how these equivalencies look in code, take a look at the [DeviceAtlas comparison implementation](https://github.com/51Degrees/device-detection-java-examples/blob/main/console/src/main/java/fiftyone/devicedetection/examples/console/comparison/DetectionImplDeviceAtlas.java) in our Java examples repository, which maps DeviceAtlas properties onto their 51Degrees counterparts. It is a skeleton: the DeviceAtlas calls are commented out and untested, so you will need to uncomment them and add the DeviceAtlas dependencies to run it. Once working, register it in [`Comparer`](https://github.com/51Degrees/device-detection-java-examples/blob/main/console/src/main/java/fiftyone/devicedetection/examples/console/comparison/Comparer.java) to benchmark both providers side by side. Note that the comparison measures detection time rather than displaying property values.
 
 
 # Obsolete DeviceAtlas capabilities

--- a/src/devicedetection/migrationguides/deviceatlas.md
+++ b/src/devicedetection/migrationguides/deviceatlas.md
@@ -5,7 +5,7 @@
 Here you'll find a list of DeviceAtlas properties and their 51Degrees equivalent. 
 Details of all available DeviceAtlas properties can be found on their website, whilst the [51Degrees property dictionary](https://51degrees.com/developers/property-dictionary) contains details of all our properties and their possible values.
 
-To see DeviceAtlas and 51Degrees detection running side by side, take a look at the [device detection comparison example](https://github.com/51Degrees/device-detection-java-examples/tree/main/console/src/main/java/fiftyone/devicedetection/examples/console/comparison) in our Java examples repository. It shows how the same User-Agent is processed by each provider, which makes the property equivalencies in the table below easier to follow.
+To see DeviceAtlas and 51Degrees detection running side by side, take a look at the [device detection comparison example](https://github.com/51Degrees/device-detection-java-examples/blob/main/console/src/main/java/fiftyone/devicedetection/examples/console/comparison/Comparer.java) in our Java examples repository. It shows how the same User-Agent is processed by each provider, which makes the property equivalencies in the table below easier to follow.
 
 
 # Obsolete DeviceAtlas capabilities

--- a/src/devicedetection/migrationguides/wurfl.md
+++ b/src/devicedetection/migrationguides/wurfl.md
@@ -6,7 +6,7 @@ Here you'll find a list of ScientiaMobile's WURFL properties and values and the 
 
 Details of all available WURFL Capabilities can be found on ScientiaMobile's website, whilst the [51Degrees property dictionary](https://51degrees.com/developers/property-dictionary) contains details of all our properties and their possible values.
 
-To see WURFL (ScientiaMobile) and 51Degrees detection running side by side, take a look at the [device detection comparison example](https://github.com/51Degrees/device-detection-java-examples/tree/main/console/src/main/java/fiftyone/devicedetection/examples/console/comparison) in our Java examples repository. It shows how the same User-Agent is processed by each provider, which makes the capability equivalencies in the table below easier to follow.
+To see WURFL (ScientiaMobile) and 51Degrees detection running side by side, take a look at the [device detection comparison example](https://github.com/51Degrees/device-detection-java-examples/blob/main/console/src/main/java/fiftyone/devicedetection/examples/console/comparison/Comparer.java) in our Java examples repository. It shows how the same User-Agent is processed by each provider, which makes the capability equivalencies in the table below easier to follow.
 
 # Obsolete WURFL capabilities
 

--- a/src/devicedetection/migrationguides/wurfl.md
+++ b/src/devicedetection/migrationguides/wurfl.md
@@ -6,7 +6,7 @@ Here you'll find a list of ScientiaMobile's WURFL properties and values and the 
 
 Details of all available WURFL Capabilities can be found on ScientiaMobile's website, whilst the [51Degrees property dictionary](https://51degrees.com/developers/property-dictionary) contains details of all our properties and their possible values.
 
-To see WURFL (ScientiaMobile) and 51Degrees detection running side by side, take a look at the [device detection comparison example](https://github.com/51Degrees/device-detection-java-examples/blob/main/console/src/main/java/fiftyone/devicedetection/examples/console/comparison/Comparer.java) in our Java examples repository. It shows how the same User-Agent is processed by each provider, which makes the capability equivalencies in the table below easier to follow.
+To see how these equivalencies look in code, take a look at the [WURFL comparison implementation](https://github.com/51Degrees/device-detection-java-examples/blob/main/console/src/main/java/fiftyone/devicedetection/examples/console/comparison/DetectionImplScientiaMobile.java) in our Java examples repository, which maps WURFL capabilities onto their 51Degrees counterparts. It is a skeleton: the WURFL calls are commented out and untested, so you will need to uncomment them and add the WURFL dependencies to run it. Once working, register it in [`Comparer`](https://github.com/51Degrees/device-detection-java-examples/blob/main/console/src/main/java/fiftyone/devicedetection/examples/console/comparison/Comparer.java) to benchmark both providers side by side. Note that the comparison measures detection time rather than displaying capability values.
 
 # Obsolete WURFL capabilities
 

--- a/src/devicedetection/migrationguides/wurfl.md
+++ b/src/devicedetection/migrationguides/wurfl.md
@@ -6,6 +6,8 @@ Here you'll find a list of ScientiaMobile's WURFL properties and values and the 
 
 Details of all available WURFL Capabilities can be found on ScientiaMobile's website, whilst the [51Degrees property dictionary](https://51degrees.com/developers/property-dictionary) contains details of all our properties and their possible values.
 
+To see WURFL (ScientiaMobile) and 51Degrees detection running side by side, take a look at the [device detection comparison example](https://github.com/51Degrees/device-detection-java-examples/tree/main/console/src/main/java/fiftyone/devicedetection/examples/console/comparison) in our Java examples repository. It shows how the same User-Agent is processed by each provider, which makes the capability equivalencies in the table below easier to follow.
+
 # Obsolete WURFL capabilities
 
 WURFL was designed in 2001 when the web and mobile were very different to now. As such, the majority of the capabilities WURFL contains have not proven relevant to businesses who've migrated to 51Degrees. 


### PR DESCRIPTION
Add a reference to the Java comparison example in the DeviceAtlas and WURFL migration guides so users can see each provider running side by side with 51Degrees when cross-referencing property equivalencies.

closes #109 