### PR TITLE
Bound the configurator basket panel and fix an invalid overflow value

### DIFF
--- a/pattern-library/source/sass/03-groups/02-conf-basket/00-basket.scss
+++ b/pattern-library/source/sass/03-groups/02-conf-basket/00-basket.scss
@@ -35,8 +35,10 @@
     background-position:center center;
     background-repeat:no-repeat;
     display:inline-block;
-    width:14px;
-    height:9px;
+    // Matched to the weight of the filter arrows above it, per the
+    // configurator pricing journey review of 22 July 2026.
+    width:18px;
+    height:12px;
     margin-right:size(0);
     .is-opened & {
       background-image:url("/images/icon-arrow-down-black.svg");
@@ -53,9 +55,21 @@
 .g-basket__content {
   height:0px;
   overflow:hidden;
+  // The panel is positioned at bottom:100% of the footer and grows upward,
+  // and .g-basket__status is positioned relative to it, so an unbounded
+  // panel both covers the option list and pushes its own collapse tab off
+  // the top of the viewport. Bounding the content box fixes both. The
+  // enclosing layout is fixed at 100vh and never body scrolls, so viewport
+  // units are safe here, as in the search dropdown. box-sizing keeps the
+  // padding inside the bound, there being no global border-box reset.
+  // Previously overflow:none, which is not a valid value and was discarded,
+  // so nothing ever scrolled. 51Degrees/configurator#68.
   .is-opened & {
     height:auto;
-    overflow:none;
+    max-height:30vh;
+    overflow-y:auto;
+    overscroll-behavior:contain;
+    box-sizing:border-box;
     padding:size(0) size(0) 0 0;
     box-shadow: $box-shadow-top-deep;
   }


### PR DESCRIPTION
Two changes to `03-groups/02-conf-basket/00-basket.scss`, the configurator's
selected-properties panel.

Reported as 51Degrees/configurator#68.

## The problem

The panel is `position:absolute` at `bottom:100%` of the footer, so it is
anchored to the footer's top edge and grows upward with nothing bounding it. Its
own collapse tab, `.g-basket__status`, is absolutely positioned relative to that
growing panel. Every extra row of property pills therefore pushes the tab
further up, and once the panel is taller than the viewport the tab is off the top
of the screen. That is the reported symptom, the user being unable to collapse
the panel again.

The open state also set `overflow:none`. That is not a valid CSS value, so the
parser discards the declaration and the panel has no scroll container at all.
Grepping the whole pattern library, this was the only occurrence.

Separately, the arrow on the collapse tab is still `14x9`. The configurator
pricing journey review of 22 July 2026 asked for `18x12` to match the weight of
the filter arrows above it, but that was only ever patched into the
configurator's own stylesheet, so anyone compiling this pattern library still got
the small one.

## The fix

The open state bounds the content box with `max-height:30vh` and
`overflow-y:auto`, which fixes both symptoms at once. The panel stops growing,
and because the tab is positioned relative to the panel it stops being pushed
away.

Viewport units are safe here because the enclosing layout is fixed at `100vh` and
never body scrolls, which is the same reason `02-components/03-main/04-search.scss`
already uses `max-height: 50vh`. `box-sizing:border-box` is set because there is
no global border-box reset, so without it the bound would exclude the `1rem` of
padding. `overscroll-behavior:contain` stops scrolling past the end of the panel
from chaining into the option list behind it.

The arrow goes to `18x12`.

## Testing

Compiled the partial with sass 1.83.4, the version this project pins, against the
abstracts and base mixins it depends on. The output is:

```css
.is-opened .g-basket__content {
  height: auto;
  max-height: 30vh;
  overflow-y: auto;
  overscroll-behavior: contain;
  box-sizing: border-box;
  padding: 1rem 1rem 0 0;
  box-shadow: 0px -3px 5px 0px hsla(0, 18.2%, 12.9%, 0.1);
}
```

which is byte for byte the rule already verified in a running configurator. No
`overflow: none` remains in the compiled output. The only warnings are the
project's existing `@import` deprecation notices, unrelated to this change.

Behaviour was measured in the configurator against the built application, at
375x812 with 53 properties selected:

| | Panel height | Panel top | Collapse tab | Can collapse |
|---|---|---|---|---|
| Before | 1744px | -1023px | -1057px | No |
| After | 244px | 477px | 444px | Yes |

## Rollout

Scoped to the configurator. `.g-basket*` is only used by the configurator
stylesheet, `conf-main.scss` being the one entry point that globs
`03-groups/*conf*`, so the docs and examples stylesheets are unaffected.

Worth knowing about the relationship between the two repositories, because it is
the reason this PR exists. The configurator does not consume this sass. It
carries a compiled copy of `conf-main.css` for Storybook plus a separate, older
compiled `main.css` that the application actually imports, and the same fix was
made there in 51Degrees/configurator#89 so the running application is fixed now.
This change is that fix at the source, so the two cannot drift.

That split is itself a problem worth solving properly. The configurator's
`main.css` has accumulated 69 selectors that exist in neither this sass nor its
own copy of `conf-main.css`, so it can no longer be regenerated from the pattern
library without losing them. Bringing the configurator's styling source into sass
is being tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
