### PR TITLE
FEAT: show the device id in the client-side example results

### DIFF
--- a/pattern-library/source/js/examples.js
+++ b/pattern-library/source/js/examples.js
@@ -49,7 +49,7 @@
       // table. Client side it is worth showing next to the server-rendered
       // one: the hardware and platform ids are resolved from JavaScript
       // evidence, so the two values differ whenever the client refines what
-      // the user agent claimed.
+      // the request headers claimed, the user agent and client hints alike.
       ['Device Id:', device.deviceid]
     ];
   }

--- a/pattern-library/source/js/examples.js
+++ b/pattern-library/source/js/examples.js
@@ -44,11 +44,12 @@
       ['Browser:', join(device.browsername, device.browserversion)],
       ['Screen width (pixels):', device.screenpixelswidth],
       ['Screen height (pixels):', device.screenpixelsheight],
-      // The device id is the hardware, platform and browser profile ids joined
-      // together, so it is the compact form of the rest of this table. Client
-      // side it is worth showing next to the server-rendered one: the hardware
-      // and platform ids are resolved from JavaScript evidence, so the two
-      // values differ whenever the client refines what the user agent claimed.
+      // The device id is the hardware, platform, browser and crawler profile
+      // ids joined together, so it is the compact form of the rest of this
+      // table. Client side it is worth showing next to the server-rendered
+      // one: the hardware and platform ids are resolved from JavaScript
+      // evidence, so the two values differ whenever the client refines what
+      // the user agent claimed.
       ['Device Id:', device.deviceid]
     ];
   }

--- a/pattern-library/source/js/examples.js
+++ b/pattern-library/source/js/examples.js
@@ -43,7 +43,13 @@
       ['Platform:', join(device.platformname, device.platformversion)],
       ['Browser:', join(device.browsername, device.browserversion)],
       ['Screen width (pixels):', device.screenpixelswidth],
-      ['Screen height (pixels):', device.screenpixelsheight]
+      ['Screen height (pixels):', device.screenpixelsheight],
+      // The device id is the hardware, platform and browser profile ids joined
+      // together, so it is the compact form of the rest of this table. Client
+      // side it is worth showing next to the server-rendered one: the hardware
+      // and platform ids are resolved from JavaScript evidence, so the two
+      // values differ whenever the client refines what the user agent claimed.
+      ['Device Id:', device.deviceid]
     ];
   }
 


### PR DESCRIPTION
### Why

The client-side results table in the shared examples helper exists to show what JavaScript evidence refines, but it omitted the one value that expresses the whole refinement. The device id is the hardware, platform, browser and crawler profile ids joined together, and the hardware and platform components are resolved client side, so it differs from the id rendered by the server whenever the client refines what the request headers claimed, the user agent and client hints alike.

### What changed

- `pattern-library/source/js/examples.js`: added a `Device Id:` row to `defaultDeviceFields`, so every web example that uses the default field set shows it alongside the server-rendered one.

`examples.min.js` is not committed here, so this is a source-only change; the minified asset is produced by the existing build when the next `examples-assets-v*` release is cut.

### How it was tested

Loaded the device-detection getting-started web example in a real browser presenting an iPhone user agent, then loaded the modified helper over the shipped one and re-bound the callback:

- server rendered `12280-128198-146368-18092` from the request headers, `Sec-CH-UA` client hints included
- the client-side results resolved `15364-17017-146368-18092` once the hardware profile evidence arrived

Only the hardware and platform components move; the browser and crawler components are unchanged. The new row renders with the refined value and the two differ, which is the behaviour the change is for. `node --check` passes on the modified file.

Consumers of the default field set pick this up when the release is cut and the example asset update runs; nothing changes for callers that pass their own `options.fields`.